### PR TITLE
Add batch_training, resume training from checkpoint, and more optimizer/scheduler options

### DIFF
--- a/biogtr/config.py
+++ b/biogtr/config.py
@@ -37,11 +37,11 @@ class Config:
             self.cfg = base_cfg
 
     def __repr__(self):
-        """Object representation of config class"""
+        """Object representation of config class."""
         return f"Config({self.cfg})"
 
     def __str__(self):
-        """String representation of config class"""
+        """String representation of config class."""
         return f"Config({self.cfg})"
 
     def set_hparams(self, hparams: dict):
@@ -77,7 +77,7 @@ class Config:
         return tracker_cfg
 
     def get_gtr_runner(self):
-        """Get lightning module for training, validation, and inference"""
+        """Get lightning module for training, validation, and inference."""
         model_params = self.cfg.model
         tracker_params = self.cfg.tracker
         optimizer_params = self.cfg.optimizer
@@ -252,5 +252,5 @@ class Config:
         )
 
     def get_ckpt_path(self):
-        """Get model ckpt path for loading"""
+        """Get model ckpt path for loading."""
         return self.cfg.model.ckpt_path

--- a/biogtr/config.py
+++ b/biogtr/config.py
@@ -5,6 +5,7 @@ import sys
 import ast
 import torch
 import pytorch_lightning as pl
+from biogtr.models.model_utils import init_optimizer, init_scheduler
 from biogtr.models.gtr_runner import GTRRunner
 from biogtr.models.global_tracking_transformer import GlobalTrackingTransformer
 from biogtr.training.losses import AssoLoss
@@ -171,7 +172,7 @@ class Config:
             A torch Optimizer with specified params
         """
         optimizer_params = self.cfg.optimizer
-        return torch.optim.Adam(params=params, **optimizer_params)
+        return init_optimizer(params, optimizer_params)
 
     def get_scheduler(
         self, optimizer: torch.optim.Optimizer
@@ -184,9 +185,7 @@ class Config:
             A torch learning rate scheduler with specified params
         """
         lr_scheduler_params = self.cfg.scheduler
-        return torch.optim.lr_scheduler.ReduceLROnPlateau(
-            optimizer=optimizer, **lr_scheduler_params
-        )
+        return init_scheduler(optimizer, lr_scheduler_params)
 
     def get_loss(self) -> AssoLoss:
         """Getter for loss functions.

--- a/biogtr/datasets/tracking_dataset.py
+++ b/biogtr/datasets/tracking_dataset.py
@@ -6,30 +6,6 @@ from torch.utils.data import DataLoader
 from biogtr.datasets.microscopy_dataset import MicroscopyDataset
 from biogtr.datasets.sleap_dataset import SleapDataset
 
-# todo: move to config
-num_workers = 0
-shuffle = True
-
-device = "cuda" if torch.cuda.is_available() else "cpu"
-
-if num_workers > 0:
-    # prevent too many open files error
-    pin_memory = True
-    torch.multiprocessing.set_sharing_strategy("file_system")
-else:
-    pin_memory = False
-
-# for dataloader if shuffling, since shuffling is done by default on cpu
-generator = torch.Generator(device=device) if shuffle else None
-
-# useful for longer training runs, but not for single iteration debugging
-# finds optimal hardware algs which has upfront time increase for first
-# iteration, quicker subsequent iterations
-
-# torch.backends.cudnn.benchmark = True
-
-# pytorch 2 logic - we set our device once here so we don't have to keep setting
-torch.set_default_device(device)
 
 """
 Lightning wrapper for tracking datasets
@@ -98,9 +74,9 @@ class TrackingDataset(LightningDataModule):
                 self.train_ds,
                 batch_size=1,
                 shuffle=True,
-                pin_memory=pin_memory,
+                pin_memory=False,
                 collate_fn=self.train_ds.no_batching_fn,
-                num_workers=num_workers,
+                num_workers=0,
                 generator=generator if torch.cuda.is_available() else None,
             )
         else:
@@ -116,9 +92,9 @@ class TrackingDataset(LightningDataModule):
                 self.val_ds,
                 batch_size=1,
                 shuffle=False,
-                pin_memory=pin_memory,
+                pin_memory=0,
                 collate_fn=self.train_ds.no_batching_fn,
-                num_workers=num_workers,
+                num_workers=False,
                 generator=None,
             )
         else:
@@ -134,9 +110,9 @@ class TrackingDataset(LightningDataModule):
                 self.test_ds,
                 batch_size=1,
                 shuffle=False,
-                pin_memory=pin_memory,
+                pin_memory=0,
                 collate_fn=self.train_ds.no_batching_fn,
-                num_workers=num_workers,
+                num_workers=False,
                 generator=None,
             )
         else:

--- a/biogtr/inference/configs/base.yaml
+++ b/biogtr/inference/configs/base.yaml
@@ -1,0 +1,20 @@
+ckpt_path: "../training/models/example/example_train/epoch=0-best-val_sw_cnt=31.06133270263672.ckpt"
+tracker:
+  overlap_thresh: 0.01
+  decay_time: 0.9
+  iou: "mult"
+  max_center_dist: 1.0
+
+dataset:
+  test_dataset:
+    slp_files: ["../training/190612_110405_wt_18159111_rig2.2@11730.slp", "../training/190612_110405_wt_18159111_rig2.2@11730.slp"]
+    video_files: ["../training/190612_110405_wt_18159111_rig2.2@11730.mp4", "../training/190612_110405_wt_18159111_rig2.2@11730.mp4"]
+    chunk: True
+    clip_length: 32
+
+dataloader:
+  test_dataloader:
+    shuffle: False
+    num_workers: 0
+
+  

--- a/biogtr/inference/track.py
+++ b/biogtr/inference/track.py
@@ -1,0 +1,123 @@
+"""Script to run inference and get out tracks."""
+
+from biogtr.config import Config
+from biogtr.models.gtr_runner import GTRRunner
+from biogtr.datasets.tracking_dataset import TrackingDataset
+from omegaconf import DictConfig
+from pprint import pprint
+from pathlib import Path
+
+import os
+import hydra
+import pandas as pd
+import pytorch_lightning as pl
+import torch
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+torch.set_default_device(device)
+
+
+def inference(
+    model: GTRRunner, dataloader: torch.utils.data.DataLoader
+) -> list[pd.DataFrame]:
+    """Run Inference.
+
+    Args:
+        model: model loaded from checkpoint used for inference
+        dataloader: dataloader containing inference data
+
+    Return:
+        List of DataFrames containing prediction results for each video
+    """
+    num_videos = len(dataloader.dataset.slp_files)
+    trainer = pl.Trainer(devices=1, limit_predict_batches=3)
+    preds = trainer.predict(model, dataloader)
+
+    vid_trajectories = [[] for i in range(num_videos)]
+
+    for batch in preds:
+        for frame in batch:
+            vid_trajectories[frame["video_id"]].append(frame)
+
+    saved = []
+
+    for video in vid_trajectories:
+        if len(video) > 0:
+            save_dict = {}
+            video_ids = []
+            frame_ids = []
+            X, Y = [], []
+            pred_track_ids = []
+            for frame in video:
+                for i in range(frame["num_detected"]):
+                    video_ids.append(frame["video_id"].item())
+                    frame_ids.append(frame["frame_id"].item())
+                    bbox = frame["bboxes"][i]
+
+                    y = (bbox[2] + bbox[0]) / 2
+                    x = (bbox[3] + bbox[1]) / 2
+                    X.append(x.item())
+                    Y.append(y.item())
+                    pred_track_ids.append(frame["pred_track_ids"][i].item())
+            save_dict["Video"] = video_ids
+            save_dict["Frame"] = frame_ids
+            save_dict["X"] = X
+            save_dict["Y"] = Y
+            save_dict["Predicted Track ID"] = pred_track_ids
+            save_df = pd.DataFrame(save_dict)
+            saved.append(save_df)
+
+    return saved
+
+
+@hydra.main(config_path="configs", config_name=None, version_base=None)
+def main(cfg: DictConfig):
+    """Main function for running inference.
+
+    handles config parsing, batch deployment and saving results
+
+    Args:
+        cfg: A dictconfig loaded from hydra containing checkpoint path and data
+    """
+    pred_cfg = Config(cfg)
+
+    if "checkpoints" in cfg.keys():
+        try:
+            index = int(os.environ["POD_INDEX"])
+        # For testing without deploying a job on runai
+        except KeyError:
+            print("Pod Index Not found! Setting index to 0")
+            index = 0
+        print(f"Pod Index: {index}")
+
+        checkpoints = pd.read_csv(cfg.checkpoints)
+        checkpoint = checkpoints.iloc[index]
+    else:
+        checkpoint = pred_cfg.get_ckpt_path()
+
+    model = GTRRunner.load_from_checkpoint(checkpoint)
+    tracker_cfg = pred_cfg.get_tracker_cfg()
+    print("Updating tracker hparams")
+    model.tracker_cfg = tracker_cfg
+    print(f"Using the following params for tracker:")
+    pprint(model.tracker_cfg)
+    dataset = pred_cfg.get_dataset(mode="test")
+
+    dataloader = pred_cfg.get_dataloader(dataset, mode="test")
+    preds = inference(model, dataloader)
+    for i, pred in enumerate(preds):
+        print(pred)
+        outdir = pred_cfg.cfg.outdir if "outdir" in pred_cfg.cfg else "./results"
+        os.makedirs(outdir, exist_ok=True)
+        outpath = os.path.join(
+            outdir,
+            f"{Path(pred_cfg.cfg.dataset.test_dataset.slp_files[i]).stem}_tracking_results",
+        )
+        print(f"Saving to {outpath}")
+        # TODO: Figure out how to overwrite sleap labels instance labels w pred instance labels then save as a new slp file
+        pred.to_csv(outpath, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/biogtr/inference/tracker.py
+++ b/biogtr/inference/tracker.py
@@ -347,7 +347,7 @@ class Tracker:
             )  # n_k x M
         else:
             last_ious = traj_score.new_zeros(traj_score.shape)
-        traj_score = post_processing.weight_iou(traj_score, self.iou, last_ious)
+        traj_score = post_processing.weight_iou(traj_score, self.iou, last_ious.cpu())
 
         ################################################################################
 

--- a/biogtr/models/global_tracking_transformer.py
+++ b/biogtr/models/global_tracking_transformer.py
@@ -28,6 +28,7 @@ class GlobalTrackingTransformer(nn.Module):
         embedding_meta: dict = None,
         return_embedding: bool = False,
         decoder_self_attn: bool = False,
+        **kwargs,
     ):
         """Initialize GTR.
 

--- a/biogtr/models/gtr_runner.py
+++ b/biogtr/models/gtr_runner.py
@@ -7,6 +7,7 @@ from biogtr.inference.tracker import Tracker
 from biogtr.inference import metrics
 from biogtr.models.global_tracking_transformer import GlobalTrackingTransformer
 from biogtr.training.losses import AssoLoss
+from biogtr.models.model_utils import init_optimizer, init_scheduler
 from pytorch_lightning import LightningModule
 
 
@@ -172,16 +173,14 @@ class GTRRunner(LightningModule):
         if self.optimizer_cfg is None:
             optimizer = torch.optim.Adam(self.parameters(), lr=1e-4, betas=(0.9, 0.999))
         else:
-            optimizer = torch.optim.Adam(self.parameters(), **self.optimizer_cfg)
+            optimizer = init_optimizer(self.parameters(), self.optimizer_cfg)
 
         if self.scheduler_cfg is None:
             scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
                 optimizer, "min", 0.5, 10
             )
         else:
-            scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-                optimizer, **self.scheduler_cfg
-            )
+            scheduler = init_scheduler(optimizer, self.scheduler_cfg)
 
         return {
             "optimizer": optimizer,

--- a/biogtr/models/gtr_runner.py
+++ b/biogtr/models/gtr_runner.py
@@ -33,10 +33,10 @@ class GTRRunner(LightningModule):
         Args:
             model_cfg: hyperparameters for GlobalTrackingTransformer
             tracker_cfg: The parameters used for the tracker post-processing
-            loss: hyperparameters for AssoLoss
+            loss_cfg: hyperparameters for AssoLoss
             optimizer_cfg: hyper parameters used for optimizer.
                        Only used to overwrite `configure_optimizer`
-            scheduler: hyperparameters for lr_scheduler used to overwrite `configure_optimizer
+            scheduler_cfg: hyperparameters for lr_scheduler used to overwrite `configure_optimizer
             train_metrics: a list of metrics to be calculated during training
             val_metrics: a list of metrics to be calculated during validation
             test_metrics: a list of metrics to be calculated at test time

--- a/biogtr/models/model_utils.py
+++ b/biogtr/models/model_utils.py
@@ -1,5 +1,5 @@
 """Module containing model helper functions."""
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Iterable
 import torch
 
 
@@ -65,3 +65,76 @@ def softmax_asso(asso_output: list[torch.Tensor]) -> list[torch.Tensor]:
         asso_active.append(asso)
 
     return asso_active  # (T, N_t, N_i)
+
+
+def init_optimizer(params: Iterable, config: dict):
+    """Initialize optimizer based on config parameters
+
+    Args:
+        params: model parameters to be optimized
+        config: optimizer hyperparameters including optimizer name
+
+    Returns:
+        optimizer: A torch.Optimizer with specified params
+    """
+
+    optimizer = config["name"]
+    optimizer_params = {
+        param: val for param, val in config.items() if param.lower() != "name"
+    }
+
+    try:
+        optimizer_class = getattr(torch.optim, optimizer)
+    except AttributeError:
+        if optimizer_class is None:
+            print(
+                f"Couldn't instantiate {optimizer} as given. Trying with capitalization"
+            )
+            optimizer_class = getattr(torch.optim, optimizer.lower().capitalize())
+        if optimizer_class is None:
+            print(
+                f"Couldnt instantiate {optimizer} with capitalization, Final attempt with all caps"
+            )
+            optimizer_class = getattr(torch.optim, optimizer.upper(), None)
+
+    if optimizer_class is None:
+        raise ValueError(f"Unsupported optimizer type: {optimizer}")
+
+    return optimizer_class(params, **optimizer_params)
+
+
+def init_scheduler(optimizer: torch.optim.Optimizer, config: dict):
+    """Initialize optimizer based on config parameters
+
+    Args:
+        optimizer: optimizer for which to adjust lr
+        config: lr scheduler hyperparameters including scheduler name name
+
+    Returns:
+        scheduler: A scheduler with specified params
+    """
+
+    scheduler = config["name"]
+    scheduler_params = {
+        param: val for param, val in config.items() if param.lower() != "name"
+    }
+    try:
+        scheduler_class = getattr(torch.optim.lr_scheduler, scheduler)
+    except AttributeError:
+        if scheduler_class is None:
+            print(
+                f"Couldn't instantiate {scheduler} as given. Trying with capitalization"
+            )
+            scheduler_class = getattr(
+                torch.optim.lr_scheduler, scheduler.lower().capitalize()
+            )
+        if scheduler_class is None:
+            print(
+                f"Couldnt instantiate {scheduler} with capitalization, Final attempt with all caps"
+            )
+            scheduler_class = getattr(torch.optim.lr_scheduler, scheduler.upper(), None)
+
+    if scheduler_class is None:
+        raise ValueError(f"Unsupported optimizer type: {scheduler}")
+
+    return scheduler_class(optimizer, **scheduler_params)

--- a/biogtr/models/model_utils.py
+++ b/biogtr/models/model_utils.py
@@ -1,6 +1,7 @@
 """Module containing model helper functions."""
 from typing import Dict, List, Tuple, Iterable
 import torch
+from copy import deepcopy
 
 
 def get_boxes_times(instances: List[Dict]) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -18,7 +19,7 @@ def get_boxes_times(instances: List[Dict]) -> Tuple[torch.Tensor, torch.Tensor]:
     _, h, w = instances[0]["img_shape"].flatten()
 
     for fidx, instance in enumerate(instances):
-        bbox = instance["bboxes"]
+        bbox = deepcopy(instance["bboxes"])
         bbox[:, [0, 2]] /= w
         bbox[:, [1, 3]] /= h
 
@@ -69,6 +70,8 @@ def softmax_asso(asso_output: list[torch.Tensor]) -> list[torch.Tensor]:
 
 def init_optimizer(params: Iterable, config: dict):
     """Initialize optimizer based on config parameters.
+
+    Allows more flexibility in which optimizer to use
 
     Allows more flexibility in which optimizer to use
 

--- a/biogtr/models/model_utils.py
+++ b/biogtr/models/model_utils.py
@@ -68,7 +68,9 @@ def softmax_asso(asso_output: list[torch.Tensor]) -> list[torch.Tensor]:
 
 
 def init_optimizer(params: Iterable, config: dict):
-    """Initialize optimizer based on config parameters
+    """Initialize optimizer based on config parameters.
+
+    Allows more flexibility in which optimizer to use
 
     Args:
         params: model parameters to be optimized
@@ -77,7 +79,6 @@ def init_optimizer(params: Iterable, config: dict):
     Returns:
         optimizer: A torch.Optimizer with specified params
     """
-
     optimizer = config["name"]
     optimizer_params = {
         param: val for param, val in config.items() if param.lower() != "name"
@@ -104,7 +105,9 @@ def init_optimizer(params: Iterable, config: dict):
 
 
 def init_scheduler(optimizer: torch.optim.Optimizer, config: dict):
-    """Initialize optimizer based on config parameters
+    """Initialize scheduler based on config parameters.
+
+    Allows more flexibility in choosing which scheduler to use.
 
     Args:
         optimizer: optimizer for which to adjust lr
@@ -113,7 +116,6 @@ def init_scheduler(optimizer: torch.optim.Optimizer, config: dict):
     Returns:
         scheduler: A scheduler with specified params
     """
-
     scheduler = config["name"]
     scheduler_params = {
         param: val for param, val in config.items() if param.lower() != "name"

--- a/biogtr/training/configs/base.yaml
+++ b/biogtr/training/configs/base.yaml
@@ -30,6 +30,7 @@ loss:
 
 #currently assumes adam. TODO adapt logic for other optimizers like sgd
 optimizer:
+  name: "Adam"
   lr: 0.001
   betas: [0.9, 0.999]
   eps: 1e-8
@@ -56,7 +57,7 @@ gtr_runner:
   train_metrics: [""]
   val_metrics: ["sw_cnt"]
   test_metrics: ["sw_cnt"]
-  
+
 dataset:
   train_dataset:
     slp_files: ['190612_110405_wt_18159111_rig2.2@11730.slp']

--- a/biogtr/training/configs/base.yaml
+++ b/biogtr/training/configs/base.yaml
@@ -1,9 +1,27 @@
 model:
-  d_model: 256
+  ckpt_path: null
+  encoder_model: "resnet18"
+  encoder_cfg: {}
+  d_model: 1024
+  nhead: 8
   num_encoder_layers: 1
   num_decoder_layers: 1
-  dim_feedforward: 256
-  feature_dim_attn_head: 256
+  dim_feedforward: 1024
+  dropout: 0.1
+  activation: "relu"
+  return_intermediate_dec: False
+  feature_dim_attn_head: 1024
+  norm: False
+  num_layers_attn_head: 2
+  dropout_attn_head: 0.1
+  embedding_meta: 
+    embedding_type: 'learned_pos_temp'
+    kwargs: 
+      learn_pos_emb_num': 16
+      learn_temp_emb_num': 16
+      over_boxes': False
+  return_embedding: False
+  decoder_self_attn: False
 
 loss:
   neg_unmatched: false
@@ -34,6 +52,11 @@ tracker:
   iou: null
   max_center_dist: null
 
+gtr_runner:
+  train_metrics: [""]
+  val_metrics: ["sw_cnt"]
+  test_metrics: ["sw_cnt"]
+  
 dataset:
   train_dataset:
     slp_files: ['190612_110405_wt_18159111_rig2.2@11730.slp']

--- a/biogtr/training/configs/test_batch_train.csv
+++ b/biogtr/training/configs/test_batch_train.csv
@@ -1,0 +1,4 @@
+model.d_model,model.dim_feedforward,model.feature_dim_attn_head,model.num_encoder_layers,model.num_decoder_layers
+256,256,256,1,1
+512,512,512,2,2
+1024,1024,1024,4,4

--- a/biogtr/training/train.py
+++ b/biogtr/training/train.py
@@ -4,7 +4,6 @@ Used for training a single model or deploying a batch train job on RUNAI CLI
 """
 from biogtr.config import Config
 from biogtr.datasets.tracking_dataset import TrackingDataset
-from biogtr.models.gtr_runner import GTRRunner
 from omegaconf import DictConfig
 from pprint import pprint
 
@@ -12,7 +11,6 @@ import os
 import hydra
 import pandas as pd
 import pytorch_lightning as pl
-import sys
 import torch
 import torch.multiprocessing
 
@@ -40,8 +38,6 @@ def main(cfg: DictConfig):
         cfg: The config dict parsed by `hydra`
     """
     train_cfg = Config(cfg)
-    pprint(f"Base train config: {train_cfg.cfg}")
-
     # update with parameters for batch train job
     if "batch_config" in cfg.keys():
         try:
@@ -55,33 +51,21 @@ def main(cfg: DictConfig):
         hparams_df = pd.read_csv(cfg.batch_config)
         hparams = hparams_df.iloc[index].to_dict()
 
-        print("Updating the following hparams to the following values")
-        pprint(hparams)
-        train_cfg.set_hparams(hparams)
-    print(f"Updated train config: {train_cfg}")
-    # update with extra cli args
-    hparams_cli = {}
-    for arg in sys.argv[1:]:
-        if arg.startswith("+"):
-            key, val = arg[1:].split("=")
-            if key in ["base_config", "params_config"]:
-                continue
-            try:
-                hparams_cli[key] = val
-            except (SyntaxError, ValueError) as e:
-                print(e)
-                pass
-
-    train_cfg.set_hparams(hparams_cli)
+        if train_cfg.set_hparams(hparams):
+            print("Updated the following hparams to the following values")
+            pprint(hparams)
+    else:
+        hparams = {}
+    pprint(f"Final train config: {train_cfg}")
 
     model = train_cfg.get_model()
-    train_dataset = train_cfg.get_dataset(type="sleap", mode="train")
+    train_dataset = train_cfg.get_dataset(mode="train")
     train_dataloader = train_cfg.get_dataloader(train_dataset, mode="train")
 
-    val_dataset = train_cfg.get_dataset(type="sleap", mode="val")
+    val_dataset = train_cfg.get_dataset(mode="val")
     val_dataloader = train_cfg.get_dataloader(val_dataset, mode="val")
 
-    test_dataset = train_cfg.get_dataset(type="sleap", mode="test")
+    test_dataset = train_cfg.get_dataset(mode="test")
     test_dataloader = train_cfg.get_dataloader(test_dataset, mode="test")
 
     dataset = TrackingDataset(
@@ -94,11 +78,10 @@ def main(cfg: DictConfig):
     # todo: get to work with multi-gpu training
     logger = train_cfg.get_logger()
 
-    callbacks = [
-        pl.callbacks.LearningRateMonitor(),
-        train_cfg.get_checkpointing("./models"),
-        train_cfg.get_early_stopping(),
-    ]
+    callbacks = []
+    _ = callbacks.extend(train_cfg.get_checkpointing())
+    _ = callbacks.append(pl.callbacks.LearningRateMonitor())
+    _ = callbacks.append(train_cfg.get_early_stopping())
 
     trainer = train_cfg.get_trainer(
         callbacks,
@@ -115,11 +98,11 @@ if __name__ == "__main__":
     # example calls:
 
     # train with base config:
-    # python train.py +base_config=configs/base.yaml
+    # python train.py --config-dir=./configs --config-name=base
     # override with params config:
-    # python train.py +base_config=configs/base.yaml +params_config=configs/params.yaml
+    # python train.py --config-dir=./configs --config-name=base +params_config=configs/params.yaml
     # override with params config, and specific params:
-    # python train.py +base_config=configs/base.yaml +params_config=configs/params.yaml +model.norm=True +model.decoder_self_attn=True +dataset.padding=10
+    # python train.py --config-dir=./configs --config-name=base +params_config=configs/params.yaml model.norm=True model.decoder_self_attn=True dataset.padding=10
     # deploy batch train job:
-    # python train.py +base_config=configs/base.yaml +batch_config=test_batch_train.yaml
+    # python train.py --config-dir=./configs --config-name=base +batch_config=test_batch_train.csv
     main()

--- a/biogtr/visualize.py
+++ b/biogtr/visualize.py
@@ -1,0 +1,292 @@
+"""Helper functions for visualizing tracking."""
+from scipy.interpolate import interp1d
+from copy import deepcopy
+from tqdm import tqdm
+from matplotlib import pyplot as plt
+from omegaconf import DictConfig
+
+import seaborn as sns
+import imageio
+import hydra
+import pandas as pd
+import numpy as np
+import cv2
+import imageio
+
+
+palette = sns.color_palette("tab10")
+
+
+def fill_missing(data: np.ndarray, kind: str = "linear") -> np.ndarray:
+    """Fills missing values independently along each dimension after the first.
+
+    Args:
+        data: the array for which to fill missing value
+        kind: How to interpolate missing values using `scipy.interpoloate.interp1d`
+
+    Returns:
+        The array with missing values filled in
+    """
+    # Store initial shape.
+    initial_shape = data.shape
+
+    # Flatten after first dim.
+    data = data.reshape((initial_shape[0], -1))
+
+    # Interpolate along each slice.
+    for i in range(data.shape[-1]):
+        y = data[:, i]
+
+        # Build interpolant.
+        x = np.flatnonzero(~np.isnan(y))
+        f = interp1d(x, y[x], kind=kind, fill_value=np.nan, bounds_error=False)
+
+        # Fill missing
+        xq = np.flatnonzero(np.isnan(y))
+        y[xq] = f(xq)
+
+        # Fill leading or trailing NaNs with the nearest non-NaN values
+        mask = np.isnan(y)
+        y[mask] = np.interp(np.flatnonzero(mask), np.flatnonzero(~mask), y[~mask])
+
+        # Save slice
+        data[:, i] = y
+
+    # Restore to initial shape.
+    data = data.reshape(initial_shape)
+
+    return data
+
+
+def annotate_video(
+    video: np.ndarray,
+    labels: pd.DataFrame,
+    key: str,
+    color_palette=palette,
+    trails: bool = True,
+    boxes: int = 64,
+    names: bool = True,
+    centroids: bool = True,
+    poses=False,
+) -> list:
+    """Annotate video frames with labels.
+
+    Labels video with bboxes, centroids, trajectory trails, and/or poses.
+
+    Args:
+        video: The video to be annotated in an ndarray
+        labels: The pandas dataframe containing the centroid and/or pose locations of the instances
+        key: The key where labels are stored in the dataframe - mostly used for choosing whether to annotate based on pred or gt labels
+        color_palette: The matplotlib colorpalette to use for annotating the video. Defaults to `tab10`
+        trails: Whether or not to include trajectory history
+        boxes: The size of the bbox. If bbox size <= 0 or None then it is not added
+        names: Whether or not to annotate with name
+        centroids: Whether or not to annotate with
+        poses: Whether or not to annotate with poses
+
+    Returns:
+        A list of annotated video frames
+    """
+    color_palette = deepcopy(color_palette)
+    annotated_frames = []
+
+    if trails:
+        track_trails = {}
+
+    for i in sorted(labels["Frame"]):
+        frame = video[i]
+        if frame.shape[0] == 1 or frame.shape[-1] == 1:
+            frame = cv2.cvtColor((frame * 255).astype(np.uint8), cv2.COLOR_GRAY2RGB)
+        else:
+            frame = (frame * 255).astype(np.uint8).copy()
+        lf = labels[labels["Frame"] == i]
+        for idx, instance in lf.iterrows():
+            if not trails:
+                track_trails = {}
+
+            if poses:
+                # TODO figure out best way to store poses (maybe pass a slp labels file too?)
+                trails = False
+                centroids = False
+                for idx, (pose, edge) in enumerate(
+                    zip(instance["poses"], instance["edges"])
+                ):
+                    pose = fill_missing(pose.numpy())
+
+                    pred_track_id = instance[key][idx].numpy().tolist()
+
+                    # Add midpt to track trail.
+                    if pred_track_id not in list(track_trails.keys()):
+                        track_trails[pred_track_id] = []
+
+                    # Select a color based on track_id.
+                    track_color_idx = pred_track_id % len(color_palette)
+                    track_color = (
+                        (np.array(color_palette[track_color_idx]) * 255)
+                        .astype(np.uint8)
+                        .tolist()[::-1]
+                    )
+
+                    for p in pose:
+                        # try:
+                        #    p = tuple([int(i) for i in p.numpy()][::-1])
+                        # except:
+                        #    continue
+
+                        p = tuple(int(i) for i in p)[::-1]
+
+                        track_trails[pred_track_id].append(p)
+
+                        frame = cv2.circle(
+                            frame, p, radius=2, color=track_color, thickness=-1
+                        )
+
+                    for e in edge:
+                        source = tuple(int(i) for i in pose[int(e[0])])[::-1]
+                        target = tuple(int(i) for i in pose[int(e[1])])[::-1]
+
+                        frame = cv2.line(frame, source, target, track_color, 1)
+
+            if (boxes is not None and boxes > 0) or centroids:
+                # Get coordinates for detected objects in the current frame.
+                x = instance["X"]
+                y = instance["Y"]
+                min_x, min_y, max_x, max_y = (
+                    int(x - boxes / 2),
+                    int(y - boxes / 2),
+                    int(x + boxes / 2),
+                    int(y + boxes / 2),
+                )
+                midpt = (int(x), int(y))
+
+                # print(midpt, type(midpt))
+
+                # assert idx < len(instance[key])
+                pred_track_id = instance[key]
+
+                # Add midpt to track trail.
+                if pred_track_id not in list(track_trails.keys()):
+                    track_trails[pred_track_id] = []
+                track_trails[pred_track_id].append(midpt)
+
+                # Select a color based on track_id.
+                track_color_idx = int(pred_track_id) % len(color_palette)
+                track_color = (
+                    (np.array(color_palette[track_color_idx]) * 255)
+                    .astype(np.uint8)
+                    .tolist()[::-1]
+                )
+
+                # print(instance[key])
+
+                # Bbox.
+                if boxes is not None and boxes > 0:
+                    frame = cv2.rectangle(
+                        frame,
+                        (min_x, min_y),
+                        (max_x, max_y),
+                        color=track_color,
+                        thickness=2,
+                    )
+
+                # Track trail.
+                if centroids:
+                    frame = cv2.circle(
+                        frame, midpt, radius=4, color=track_color, thickness=-1
+                    )
+                    for i in range(0, len(track_trails[pred_track_id]) - 1):
+                        frame = cv2.circle(
+                            frame,
+                            track_trails[pred_track_id][i],
+                            radius=4,
+                            color=track_color,
+                            thickness=-1,
+                        )
+                        frame = cv2.line(
+                            frame,
+                            track_trails[pred_track_id][i],
+                            track_trails[pred_track_id][i + 1],
+                            color=track_color,
+                            thickness=2,
+                        )
+
+            # Track name.
+            if names:
+                frame = cv2.putText(
+                    frame,
+                    # f"idx:{idx} | track_{pred_track_id}",
+                    f"track_{pred_track_id}",
+                    org=(int(min_x), max(0, int(min_y) - 10)),
+                    fontFace=cv2.FONT_HERSHEY_SIMPLEX,
+                    fontScale=0.9,
+                    color=track_color,
+                    thickness=2,
+                )
+        annotated_frames.append(frame)
+
+    return annotated_frames
+
+
+def save_vid(
+    annotated_frames: list,
+    vid_dir: str = ".",
+    vid_name: str = "debug_animal",
+    fps: int = 30,
+):
+    """Save video to file.
+
+    Args:
+        annotated_frames: a list of frames annotated by `annotate_frames`
+        vid_dir: The directory to store the annotated video
+        vid_name: The name of the annotated file.
+        fps: The frame rate in frames per second of the annotated video
+    """
+    vid_path = f"{vid_dir}/{vid_name}_annotated"
+    for idx, (ds_name, data) in enumerate([(vid_path, annotated_frames)]):
+        imageio.mimwrite(f"{ds_name}.mp4", data, fps=fps, macro_block_size=1)
+
+
+def color(val: float, thresh: float = 0.01) -> str:
+    """Highlight value in dataframe if it is over a threshold.
+
+    Args:
+        val: The value to color
+        thresh: The threshold for which to color
+
+    Returns:
+        A string containing how to highlight the value
+    """
+    color = "lightblue" if float(val) > thresh else ""
+    return f"background-color: {color}"
+
+
+def bold(val: float, thresh: float = 0.01) -> str:
+    """Bold value if it is over a threshold.
+
+    Args:
+        val: The value to bold or not
+        thresh: The threshold the value has to exceed to be bolded
+
+    Returns:
+        A string indicating how to bold the item.
+    """
+    bold = "bold" if float(val) > thresh else ""
+    return f"font-weight: {bold}"
+
+
+@hydra.main(config_path=None, config_name=None, version_base=None)
+def main(cfg: DictConfig):
+    """Main function for visualizations script.
+
+    Takes in a path to a video + labels file, annotates a video and saves it to the specified path
+    """
+    labels = pd.read_csv(cfg.labels_path)
+    vid_reader = imageio.get_reader(cfg.vid_path, "ffmpeg")
+    video = np.stack([vid_reader.get_data(i) for i in sorted(labels["Frame"].unique())])
+    print(f"Video shape: {video.shape}")
+    annotated_frames = annotate_video(video, labels, **cfg.annotate)
+    save_vid(annotated_frames, **cfg.save)
+
+
+if __name__ == "__main__":
+    main()

--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,4 @@ dependencies:
     - sleap-io
     - "--editable=.[dev]"
     - imageio[ffmpeg]
+    - hydra-core

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -22,3 +22,4 @@ dependencies:
     - sleap-io
     - "--editable=.[dev]"
     - imageio[ffmpeg]
+    - hydra-core

--- a/tests/configs/base.yaml
+++ b/tests/configs/base.yaml
@@ -2,15 +2,15 @@ model:
   ckpt_path: null
   encoder_model: "resnet18"
   encoder_cfg: {}
-  d_model: 1024
+  d_model: 512
   nhead: 8
   num_encoder_layers: 1
   num_decoder_layers: 1
-  dim_feedforward: 1024
+  dim_feedforward: 512
   dropout: 0.1
   activation: "relu"
   return_intermediate_dec: False
-  feature_dim_attn_head: 1024
+  feature_dim_attn_head: 512
   norm: False
   num_layers_attn_head: 2
   dropout_attn_head: 0.1
@@ -61,30 +61,30 @@ runner:
 
 dataset:
   train_dataset:
-    slp_files: ['190612_110405_wt_18159111_rig2.2@11730.slp']
-    video_files: ['190612_110405_wt_18159111_rig2.2@11730.mp4']
+    slp_files: ['tests/data/sleap/two_flies.slp']
+    video_files: ['tests/data/sleap/two_flies.mp4']
     padding: 5
     crop_size: 128
     chunk: true
-    clip_length: 32
+    clip_length: 4
     crop_type: 'centroid'
 
   val_dataset:
-    slp_files: ['190612_110405_wt_18159111_rig2.2@11730.slp']
-    video_files: ['190612_110405_wt_18159111_rig2.2@11730.mp4']
+    slp_files: ['tests/data/sleap/two_flies.slp']
+    video_files: ['tests/data/sleap/two_flies.mp4']
     padding: 5
     crop_size: 128 
     chunk: True
-    clip_length: 32
+    clip_length: 8
     crop_type: 'centroid'
 
   test_dataset:
-    slp_files: ['190612_110405_wt_18159111_rig2.2@11730.slp']
-    video_files: ['190612_110405_wt_18159111_rig2.2@11730.mp4']
+    slp_files: ['tests/data/sleap/two_flies.slp']
+    video_files: ['tests/data/sleap/two_flies.mp4']
     padding: 5
     crop_size: 128 
     chunk: True
-    clip_length: 32
+    clip_length: 16
     crop_type: 'centroid'
 
 dataloader:

--- a/tests/configs/params.yaml
+++ b/tests/configs/params.yaml
@@ -2,13 +2,13 @@ model:
   num_encoder_layers: 2
   num_decoder_layers: 2
   embedding_meta:
-    embedding_type: 'learned_pos'
-    kwargs:
-      learn_pos_emb_num: 16
-      over_boxes: True
+      embedding_type: 'learned_pos'
+      kwargs:
+        learn_pos_num: 16,
+        over_boxes: True
 
 dataset:
   train_dataset:
     slp_files: ['190612_110405_wt_18159111_rig2.2@11730.slp']
     video_files: ['190612_110405_wt_18159111_rig2.2@11730.mp4']
-    clip_length: 16
+    clip_length: 32

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,3 @@
 """Config for pytests."""
 from tests.fixtures.datasets import *
+from tests.fixtures.configs import *

--- a/tests/fixtures/configs.py
+++ b/tests/fixtures/configs.py
@@ -1,0 +1,18 @@
+import os
+import pytest
+
+
+@pytest.fixture
+def config_dir(pytestconfig):
+    """Dir path to sleap data."""
+    return os.path.join(pytestconfig.rootdir, "tests/configs")
+
+
+@pytest.fixture
+def base_config(config_dir):
+    return os.path.join(config_dir, "base.yaml")
+
+
+@pytest.fixture
+def params_config(config_dir):
+    return os.path.join(config_dir, "params.yaml")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,99 @@
+"""Tests for `config.py`"""
+
+from omegaconf import OmegaConf
+from biogtr.config import Config
+from biogtr.models.global_tracking_transformer import GlobalTrackingTransformer
+from biogtr.models.gtr_runner import GTRRunner
+
+import torch
+
+
+def test_init(base_config, params_config):
+    """Test the `__init__` function of `Config`.
+
+    Load + merge
+
+    Args:
+        base_config: the initial config params
+        params_config: the config params to override
+    """
+    base_cfg = OmegaConf.load(base_config)
+    base_cfg["params_config"] = params_config
+    cfg = Config(base_cfg)
+
+    assert cfg.cfg.model.num_encoder_layers == 2
+    assert cfg.cfg.dataset.train_dataset.clip_length == 32
+    assert cfg.cfg.dataset.train_dataset.padding == 5
+    assert "val_dataset" in cfg.cfg.dataset
+
+
+def test_setter(base_config):
+    """Test the setter function of `Config`.
+
+    set hyperparameters
+
+    Args:
+        base_config: the initial config params
+    """
+    base_cfg = OmegaConf.load(base_config)
+    cfg = Config(base_cfg)
+    hparams = {
+        "model.num_encoder_layers": 1,
+        "logging.name": "test_config",
+        "dataset.train_dataset.chunk": False,
+    }
+
+    assert cfg.set_hparams(hparams)
+    assert cfg.cfg.model.num_encoder_layers == 1
+    assert cfg.cfg.tracker.window_size == 8
+
+    hparams = {"test_config": -1}
+
+    assert cfg.set_hparams(hparams)
+    assert "test_config" in cfg.cfg
+    assert cfg.cfg.test_config == -1
+
+
+def test_getters(base_config):
+    """Test each getter function in the config class.
+
+    Args:
+        base_config: the config params to override
+    """
+    base_cfg = OmegaConf.load(base_config)
+    cfg = Config(base_cfg)
+
+    model = cfg.get_model()
+    assert isinstance(model, GlobalTrackingTransformer)
+    assert model.transformer.d_model == 512
+
+    tracker_cfg = cfg.get_tracker_cfg()
+    assert set(
+        [
+            "window_size",
+            "use_vis_feats",
+            "overlap_thresh",
+            "mult_thresh",
+            "decay_time",
+            "iou",
+            "max_center_dist",
+        ]
+    ) == set(tracker_cfg.keys())
+    assert tracker_cfg["window_size"] == 8
+
+    gtr_runner = cfg.get_gtr_runner()
+    assert isinstance(gtr_runner, GTRRunner)
+    assert gtr_runner.model.transformer.d_model == 512
+
+    ds = cfg.get_dataset("train")
+    assert ds.clip_length == 4
+    ds = cfg.get_dataset("val")
+    assert ds.clip_length == 8
+    ds = cfg.get_dataset("test")
+    assert ds.clip_length == 16
+
+    optim = cfg.get_optimizer(model.parameters())
+    assert isinstance(optim, torch.optim.Adam)
+
+    scheduler = cfg.get_scheduler(optim)
+    assert isinstance(scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -66,6 +66,26 @@ def test_gtr_runner():
 
     gtr_runner = GTRRunner()
 
+    optim_scheduler = gtr_runner.configure_optimizers()
+
+    assert isinstance(optim_scheduler["optimizer"], torch.optim.Adam)
+    assert isinstance(
+        optim_scheduler["lr_scheduler"]["scheduler"],
+        torch.optim.lr_scheduler.ReduceLROnPlateau,
+    )
+
+    optim_cfg = {"name": "SGD", "lr": 1e-3}
+    scheduler_cfg = {"name": "CosineAnnealingLR", "T_max": 1}
+
+    gtr_runner = GTRRunner(optimizer_cfg=optim_cfg, scheduler_cfg=scheduler_cfg)
+    optim_scheduler = gtr_runner.configure_optimizers()
+
+    assert isinstance(optim_scheduler["optimizer"], torch.optim.SGD)
+    assert isinstance(
+        optim_scheduler["lr_scheduler"]["scheduler"],
+        torch.optim.lr_scheduler.CosineAnnealingLR,
+    )
+
     for epoch in range(epochs):
         for i, batch in enumerate(train_ds):
             assert gtr_runner.model.training

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -64,33 +64,7 @@ def test_gtr_runner():
             )
         train_ds.append([instances])
 
-    embedding_meta = {
-        "embedding_type": "fixed_pos",
-        "kwargs": {"temperature": num_detected, "scale": num_frames, "normalize": True},
-    }
-
-    tracking_transformer = GlobalTrackingTransformer(
-        encoder_model="resnet18",
-        encoder_cfg={"weights": "ResNet18_Weights.DEFAULT"},
-        d_model=feats,
-        num_encoder_layers=1,
-        num_decoder_layers=1,
-        dim_feedforward=feats,
-        feature_dim_attn_head=feats,
-        embedding_meta=embedding_meta,
-        return_embedding=True,
-    )
-    loss = AssoLoss()
-    tracker_cfg = {
-        "window_size": 8,
-        "use_vis_feats": True,
-        "overlap_thresh": 0.01,
-        "mult_thresh": True,
-        "decay_time": None,
-        "iou": None,
-        "max_center_dist": None,
-    }
-    gtr_runner = GTRRunner(tracking_transformer, tracker_cfg, loss)
+    gtr_runner = GTRRunner()
 
     for epoch in range(epochs):
         for i, batch in enumerate(train_ds):


### PR DESCRIPTION
* Added batch_training as an option to `train.py` if user calls it as `train.py +base_params=base.yaml +batch_cfg=hparams.csv`
* Added ability to resume from checkpoint
* moved initialization of GTR model + loss into LightningModule to reduce checkpoint file size
* added more flexibility in optimizer/scheduler choice by using an init function to retrieve optimizer and scheduler based on config