### PR TITLE
Refactor embeddings

### DIFF
--- a/biogtr/models/embedding.py
+++ b/biogtr/models/embedding.py
@@ -211,9 +211,9 @@ class Embedding(torch.nn.Module):
         right_emb = pos_emb_table.gather(
             0, right_ind[:, :, None].to(pos_emb_table.device).expand(N, 4, f)
         )  # N x 4 x d
-        pos_emb = left_weight[:, :, None] * left_emb.to(
+        pos_emb = left_weight[:, :, None] * right_emb.to(
             left_weight.device
-        ) + right_weight[:, :, None] * right_emb.to(right_weight.device)
+        ) + right_weight[:, :, None] * left_emb.to(right_weight.device)
 
         pos_emb = pos_emb.view(N, 4 * f)
 

--- a/biogtr/models/embedding.py
+++ b/biogtr/models/embedding.py
@@ -106,7 +106,7 @@ class Embedding(torch.nn.Module):
 
         if mode.lower() not in self.EMB_MODES:
             raise ValueError(
-                f"Embedding `mode` must be one of {self.EMB_MODE} not {mode}"
+                f"Embedding `mode` must be one of {self.EMB_MODES} not {mode}"
             )
 
         if mode == "fixed" and type == "temp":

--- a/biogtr/models/global_tracking_transformer.py
+++ b/biogtr/models/global_tracking_transformer.py
@@ -25,7 +25,7 @@ class GlobalTrackingTransformer(nn.Module):
         norm: bool = False,
         num_layers_attn_head: int = 2,
         dropout_attn_head: int = 0.1,
-        embedding_meta: dict = {"pos": None, "temp": None},
+        embedding_meta: dict = None,
         return_embedding: bool = False,
         decoder_self_attn: bool = False,
         **kwargs,
@@ -49,12 +49,14 @@ class GlobalTrackingTransformer(nn.Module):
             embedding_meta: Metadata for positional embeddings. See below.
             return_embedding: Whether to return the positional embeddings
             decoder_self_attn: If True, use decoder self attention.
-            embedding_meta: By default this will be an empty dict and indicate
+
+            More details on `embedding_meta`:
+                By default this will be an empty dict and indicate
                 that no positional embeddings should be used. To use the positional embeddings
                 pass in a dictionary containing a "pos" and "temp" key with subdictionaries for correct parameters ie:
                 {"pos": {'mode': 'learned', 'emb_num': 16, 'over_boxes: 'True'},
-                "temp": {'mode': 'learned', 'emb_num': 16}
-                }. See `embedding.py` for more information on correct arguments for initialization.
+                "temp": {'mode': 'learned', 'emb_num': 16}}. (see `biogtr.models.embeddings.Embedding.EMB_TYPES`
+                and `biogtr.models.embeddings.Embedding.EMB_MODES` for embedding parameters).
         """
         super().__init__()
 

--- a/biogtr/models/global_tracking_transformer.py
+++ b/biogtr/models/global_tracking_transformer.py
@@ -19,15 +19,13 @@ class GlobalTrackingTransformer(nn.Module):
         nhead: int = 8,
         num_encoder_layers: int = 6,
         num_decoder_layers: int = 6,
-        dim_feedforward: int = 1024,
         dropout: int = 0.1,
         activation: str = "relu",
         return_intermediate_dec: bool = False,
-        feature_dim_attn_head: int = 1024,
         norm: bool = False,
         num_layers_attn_head: int = 2,
         dropout_attn_head: int = 0.1,
-        embedding_meta: dict = None,
+        embedding_meta: dict = {"pos": None, "temp": None},
         return_embedding: bool = False,
         decoder_self_attn: bool = False,
         **kwargs,
@@ -42,40 +40,21 @@ class GlobalTrackingTransformer(nn.Module):
             nhead: The number of heads in the transfomer encoder/decoder.
             num_encoder_layers: The number of encoder-layers in the encoder.
             num_decoder_layers: The number of decoder-layers in the decoder.
-            dim_feedforward: The dimension of the feedforward layers of the transformer.
             dropout: Dropout value applied to the output of transformer layers.
             activation: Activation function to use.
             return_intermediate_dec: Return intermediate layers from decoder.
             norm: If True, normalize output of encoder and decoder.
-            feature_dim_attn_head: The number of features in the attention head.
             num_layers_attn_head: The number of layers in the attention head.
             dropout_attn_head: Dropout value for the attention_head.
             embedding_meta: Metadata for positional embeddings. See below.
             return_embedding: Whether to return the positional embeddings
             decoder_self_attn: If True, use decoder self attention.
             embedding_meta: By default this will be an empty dict and indicate
-                that no positional embeddings should be used. To use positional
-                embeddings, a dict should be passed with the type of embedding to
-                use. Valid options are:
-                    * learned_pos: only learned position embeddings
-                    * learned_temp: only learned temporal embeddings
-                    * learned_pos_temp: learned position and temporal embeddings
-                    * fixed_pos: fixed sine position embeddings
-                    * fixed_pos_temp: fixed sine position and learned temporal embeddings
-                You can additionally pass kwargs to override the default
-                embedding values (see embedding.py function methods for relevant
-                embedding parameters). Example:
-                    embedding_meta = {
-                        'embedding_type': 'learned_pos_temp',
-                        'kwargs': {
-                            'learn_pos_emb_num': 16,
-                            'learn_temp_emb_num': 16,
-                            'over_boxes': False
-                        }
-                    }
-                Note: Embedding features are handled directly in the forward
-                pass for each case. Overriding the features through kwargs will
-                likely throw errors due to incorrect tensor shapes.
+                that no positional embeddings should be used. To use the positional embeddings
+                pass in a dictionary containing a "pos" and "temp" key with subdictionaries for correct parameters ie:
+                {"pos": {'mode': 'learned', 'emb_num': 16, 'over_boxes: 'True'},
+                "temp": {'mode': 'learned', 'emb_num': 16}
+                }. See `embedding.py` for more information on correct arguments for initialization.
         """
         super().__init__()
 
@@ -86,11 +65,9 @@ class GlobalTrackingTransformer(nn.Module):
             nhead=nhead,
             num_encoder_layers=num_encoder_layers,
             num_decoder_layers=num_decoder_layers,
-            dim_feedforward=dim_feedforward,
             dropout=dropout,
             activation=activation,
             return_intermediate_dec=return_intermediate_dec,
-            feature_dim_attn_head=feature_dim_attn_head,
             norm=norm,
             num_layers_attn_head=num_layers_attn_head,
             dropout_attn_head=dropout_attn_head,

--- a/biogtr/models/transformer.py
+++ b/biogtr/models/transformer.py
@@ -60,30 +60,13 @@ class Transformer(torch.nn.Module):
             return_embedding: Whether to return the positional embeddings
             decoder_self_attn: If True, use decoder self attention.
 
-            embedding_meta: By default this will be an empty dict and indicate
-                that no positional embeddings should be used. To use positional
-                embeddings, a dict should be passed with the type of embedding to
-                use. Valid options are:
-                    * learned_pos: only learned position embeddings
-                    * learned_temp: only learned temporal embeddings
-                    * learned_pos_temp: learned position and temporal embeddings
-                    * fixed_pos: fixed sine position embeddings
-                    * fixed_pos_temp: fixed sine position and learned temporal embeddings
-                You can additionally pass kwargs to override the default
-                embedding values (see embedding.py function methods for relevant
-                embedding parameters). Example:
-
-                    embedding_meta = {
-                        'embedding_type': 'learned_pos_temp',
-                        'kwargs': {
-                            'learn_pos_emb_num': 16,
-                            'learn_temp_emb_num': 16,
-                            'over_boxes': False
-                        }
-                    }
-                Note: Embedding features are handled directly in the forward
-                pass for each case. Overriding the features through kwargs will
-                likely throw errors due to incorrect tensor shapes.
+            More details on `embedding_meta`: 
+                By default this will be an empty dict and indicate
+                that no positional embeddings should be used. To use the positional embeddings
+                pass in a dictionary containing a "pos" and "temp" key with subdictionaries for correct parameters ie:
+                {"pos": {'mode': 'learned', 'emb_num': 16, 'over_boxes: 'True'},
+                "temp": {'mode': 'learned', 'emb_num': 16}}. (see `biogtr.models.embeddings.Embedding.EMB_TYPES` 
+                and `biogtr.models.embeddings.Embedding.EMB_MODES` for embedding parameters). 
         """
         super().__init__()
 
@@ -92,21 +75,21 @@ class Transformer(torch.nn.Module):
         self.embedding_meta = embedding_meta
         self.return_embedding = return_embedding
 
-        self.pos_emb = Embedding(type="", features=self.d_model)
-        self.temp_emb = Embedding(type="", features=self.d_model)
+        self.pos_emb = Embedding(emb_type="off", mode="off", features=self.d_model)
+        self.temp_emb = Embedding(emb_type="off", mode="off", features=self.d_model)
 
         if self.embedding_meta:
             if "pos" in self.embedding_meta:
                 pos_emb_cfg = self.embedding_meta["pos"]
                 if pos_emb_cfg:
                     self.pos_emb = Embedding(
-                        type="pos", features=self.d_model, **pos_emb_cfg
+                        emb_type="pos", features=self.d_model, **pos_emb_cfg
                     )
             if "temp" in self.embedding_meta:
                 temp_emb_cfg = self.embedding_meta["temp"]
                 if temp_emb_cfg:
                     self.temp_emb = Embedding(
-                        type="temp", features=self.d_model, **temp_emb_cfg
+                        emb_type="temp", features=self.d_model, **temp_emb_cfg
                     )
 
         # Transformer Encoder

--- a/biogtr/models/transformer.py
+++ b/biogtr/models/transformer.py
@@ -60,13 +60,13 @@ class Transformer(torch.nn.Module):
             return_embedding: Whether to return the positional embeddings
             decoder_self_attn: If True, use decoder self attention.
 
-            More details on `embedding_meta`: 
+            More details on `embedding_meta`:
                 By default this will be an empty dict and indicate
                 that no positional embeddings should be used. To use the positional embeddings
                 pass in a dictionary containing a "pos" and "temp" key with subdictionaries for correct parameters ie:
                 {"pos": {'mode': 'learned', 'emb_num': 16, 'over_boxes: 'True'},
-                "temp": {'mode': 'learned', 'emb_num': 16}}. (see `biogtr.models.embeddings.Embedding.EMB_TYPES` 
-                and `biogtr.models.embeddings.Embedding.EMB_MODES` for embedding parameters). 
+                "temp": {'mode': 'learned', 'emb_num': 16}}. (see `biogtr.models.embeddings.Embedding.EMB_TYPES`
+                and `biogtr.models.embeddings.Embedding.EMB_MODES` for embedding parameters).
         """
         super().__init__()
 

--- a/biogtr/training/configs/base.yaml
+++ b/biogtr/training/configs/base.yaml
@@ -14,11 +14,11 @@ model:
   dropout_attn_head: 0.1
   embedding_meta: 
     pos:
-      type: "learned"
+      mode: "learned"
       emb_num: 16
       over_boxes: false
     temp:
-      type: "learned"
+      mode: "learned"
       emb_num: 16
   return_embedding: False
   decoder_self_attn: False

--- a/biogtr/training/configs/base.yaml
+++ b/biogtr/training/configs/base.yaml
@@ -6,20 +6,20 @@ model:
   nhead: 8
   num_encoder_layers: 1
   num_decoder_layers: 1
-  dim_feedforward: 1024
   dropout: 0.1
   activation: "relu"
   return_intermediate_dec: False
-  feature_dim_attn_head: 1024
   norm: False
   num_layers_attn_head: 2
   dropout_attn_head: 0.1
   embedding_meta: 
-    embedding_type: 'learned_pos_temp'
-    kwargs: 
-      learn_pos_emb_num: 16
-      learn_temp_emb_num: 16
-      over_boxes: False
+    pos:
+      type: "learned"
+      emb_num: 16
+      over_boxes: false
+    temp:
+      type: "learned"
+      emb_num: 16
   return_embedding: False
   decoder_self_attn: False
 

--- a/biogtr/training/configs/params.yaml
+++ b/biogtr/training/configs/params.yaml
@@ -2,11 +2,11 @@ model:
   num_encoder_layers: 2
   num_decoder_layers: 2
   embedding_meta:
-    embedding_type: 'learned_pos'
-    kwargs:
-      learn_pos_emb_num: 16
+    pos:
+      type: learned
+      emb_num: 16
       over_boxes: True
-
+    temp: null
 dataset:
   train_dataset:
     slp_files: ['190612_110405_wt_18159111_rig2.2@11730.slp']

--- a/biogtr/training/configs/params.yaml
+++ b/biogtr/training/configs/params.yaml
@@ -3,10 +3,11 @@ model:
   num_decoder_layers: 2
   embedding_meta:
     pos:
-      type: learned
+      mode: learned
       emb_num: 16
       over_boxes: True
-    temp: null
+    temp: 
+      mode: "off"
 dataset:
   train_dataset:
     slp_files: ['190612_110405_wt_18159111_rig2.2@11730.slp']

--- a/tests/configs/base.yaml
+++ b/tests/configs/base.yaml
@@ -6,20 +6,21 @@ model:
   nhead: 8
   num_encoder_layers: 1
   num_decoder_layers: 1
-  dim_feedforward: 512
   dropout: 0.1
   activation: "relu"
   return_intermediate_dec: False
-  feature_dim_attn_head: 512
   norm: False
   num_layers_attn_head: 2
   dropout_attn_head: 0.1
   embedding_meta: 
-    embedding_type: 'learned_pos_temp'
-    kwargs: 
-      learn_pos_emb_num: 16
-      learn_temp_emb_num: 16
+    pos: 
+      mode: 'learned'
+      emb_num: 16
       over_boxes: False
+    temp:
+      mode: 'learned'
+      emb_num: 16
+
   return_embedding: False
   decoder_self_attn: False
 

--- a/tests/configs/params.yaml
+++ b/tests/configs/params.yaml
@@ -7,7 +7,8 @@ model:
           mode: 'learned'
           emb_num: 16
           over_boxes: True
-        temp: null
+        temp: 
+          mode: "off"
 
 dataset:
   train_dataset:
@@ -29,3 +30,4 @@ trainer:
   limit_test_batches: 1
   limit_val_batches: 1
   max_epochs: 1
+  enable_checkpointing: true 

--- a/tests/configs/params.yaml
+++ b/tests/configs/params.yaml
@@ -2,10 +2,12 @@ model:
   num_encoder_layers: 2
   num_decoder_layers: 2
   embedding_meta:
-      embedding_type: 'learned_pos'
-      kwargs:
-        learn_pos_num: 16,
-        over_boxes: True
+      embedding_type: 
+        pos: 
+          mode: 'learned'
+          emb_num: 16
+          over_boxes: True
+        temp: null
 
 dataset:
   train_dataset:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -66,41 +66,41 @@ def test_embedding_validity():
 
     # this would throw assertion since embedding should be "pos"
     with pytest.raises(Exception):
-        _ = Embedding(type="position", mode="learned")
+        _ = Embedding(emb_type="position", mode="learned", features=128)
     with pytest.raises(Exception):
-        _ = Embedding(type="position", mode="fixed")
+        _ = Embedding(emb_type="position", mode="fixed", features=128)
 
     with pytest.raises(Exception):
-        _ = Embedding(type="temporal", mode="learned")
+        _ = Embedding(emb_type="temporal", mode="learned", features=128)
     with pytest.raises(Exception):
-        _ = Embedding(type="position", mode="fixed")
+        _ = Embedding(emb_type="position", mode="fixed", features=128)
 
     with pytest.raises(Exception):
-        _ = Embedding(type="pos", mode="learn")
+        _ = Embedding(emb_type="pos", mode="learn", features=128)
     with pytest.raises(Exception):
-        _ = Embedding(type="temp", mode="learn")
+        _ = Embedding(emb_type="temp", mode="learn", features=128)
 
     with pytest.raises(Exception):
-        _ = Embedding(type="pos", mode="fix")
+        _ = Embedding(emb_type="pos", mode="fix", features=128)
     with pytest.raises(Exception):
-        _ = Embedding(type="temp", mode="fix")
+        _ = Embedding(emb_type="temp", mode="fix", features=128)
 
     with pytest.raises(Exception):
-        _ = Embedding(type="position", mode="learn")
+        _ = Embedding(emb_type="position", mode="learn", features=128)
     with pytest.raises(Exception):
-        _ = Embedding(type="temporal", mode="learn")
+        _ = Embedding(emb_type="temporal", mode="learn", features=128)
     with pytest.raises(Exception):
-        _ = Embedding(type="position", mode="fix")
+        _ = Embedding(emb_type="position", mode="fix", features=128)
     with pytest.raises(Exception):
-        _ = Embedding(type="temporal", mode="learn")
+        _ = Embedding(emb_type="temporal", mode="learn", features=128)
 
     with pytest.raises(Exception):
-        _ = Embedding(type="temp", mode="fixed")
+        _ = Embedding(emb_type="temp", mode="fixed", features=128)
 
-    _ = Embedding(type="temp", mode="learned")
-    _ = Embedding(type="pos", mode="learned")
+    _ = Embedding(emb_type="temp", mode="learned", features=128)
+    _ = Embedding(emb_type="pos", mode="learned", features=128)
 
-    _ = Embedding(type="pos", mode="learned")
+    _ = Embedding(emb_type="pos", mode="learned", features=128)
 
 
 def test_embedding():
@@ -116,7 +116,7 @@ def test_embedding():
     times = torch.rand(size=(N,))
 
     pos_emb = Embedding(
-        type="pos",
+        emb_type="pos",
         mode="fixed",
         features=d_model,
         temperature=objects,
@@ -126,11 +126,29 @@ def test_embedding():
 
     sine_pos_emb = pos_emb(boxes)
 
-    pos_emb = Embedding(type="pos", mode="learned", features=d_model, emb_num=100)
+    pos_emb = Embedding(emb_type="pos", mode="learned", features=d_model, emb_num=100)
     learned_pos_emb = pos_emb(boxes)
 
-    temp_emb = Embedding(type="temp", mode="learned", features=d_model, emb_num=16)
+    temp_emb = Embedding(emb_type="temp", mode="learned", features=d_model, emb_num=16)
     learned_temp_emb = temp_emb(times)
+
+    pos_emb_off = Embedding(emb_type="pos", mode="off", features=d_model)
+    off_pos_emb = pos_emb_off(boxes)
+
+    temp_emb_off = Embedding(emb_type="temp", mode="off", features=d_model)
+    off_temp_emb = temp_emb_off(times)
+
+    learned_emb_off = Embedding(emb_type="off", mode="learned", features=d_model)
+    off_learned_emb_boxes = learned_emb_off(boxes)
+    off_learned_emb_times = learned_emb_off(times)
+
+    fixed_emb_off = Embedding(emb_type="off", mode="fixed", features=d_model)
+    off_fixed_emb_boxes = fixed_emb_off(boxes)
+    off_fixed_emb_times = fixed_emb_off(times)
+
+    off_emb = Embedding(emb_type="off", mode="off", features=d_model)
+    off_emb_boxes = off_emb(boxes)
+    off_emb_times = off_emb(times)
 
     assert sine_pos_emb.size() == (N, d_model)
     assert learned_pos_emb.size() == (N, d_model)
@@ -139,6 +157,24 @@ def test_embedding():
     assert not torch.equal(sine_pos_emb, learned_pos_emb)
     assert not torch.equal(sine_pos_emb, learned_temp_emb)
     assert not torch.equal(learned_pos_emb, learned_temp_emb)
+
+    assert off_pos_emb.size() == (N, d_model)
+    assert off_temp_emb.size() == (N, d_model)
+    assert off_learned_emb_boxes.size() == (N, d_model)
+    assert off_learned_emb_times.size() == (N, d_model)
+    assert off_fixed_emb_boxes.size() == (N, d_model)
+    assert off_fixed_emb_times.size() == (N, d_model)
+    assert off_emb_boxes.size() == (N, d_model)
+    assert off_emb_times.size() == (N, d_model)
+
+    assert not off_pos_emb.any()
+    assert not off_temp_emb.any()
+    assert not off_learned_emb_boxes.any()
+    assert not off_learned_emb_times.any()
+    assert not off_fixed_emb_boxes.any()
+    assert not off_fixed_emb_times.any()
+    assert not off_emb_boxes.any()
+    assert not off_emb_times.any()
 
 
 def test_embedding_kwargs():
@@ -154,7 +190,7 @@ def test_embedding_kwargs():
 
     # sine embedding
 
-    sine_no_args = Embedding("pos", "fixed")(boxes)
+    sine_no_args = Embedding("pos", "fixed", 128)(boxes)
 
     sine_args = {
         "temperature": objects,
@@ -162,44 +198,27 @@ def test_embedding_kwargs():
         "normalize": True,
     }
 
-    sine_with_args = Embedding("pos", "fixed", **sine_args)(boxes)
+    sine_with_args = Embedding("pos", "fixed", 128, **sine_args)(boxes)
 
     assert not torch.equal(sine_no_args, sine_with_args)
 
     # learned pos embedding
 
-    lp_no_args = Embedding("pos", "learned")(boxes)
+    lp_no_args = Embedding("pos", "learned", 128)
 
     lp_args = {"emb_num": 100, "over_boxes": False}
 
-    lp_with_args = Embedding("pos", "learned", **lp_args)(boxes)
+    lp_with_args = Embedding("pos", "learned", 128, **lp_args)
+    assert lp_no_args.lookup.weight.shape != lp_with_args.lookup.weight.shape
 
-    assert not torch.equal(lp_no_args, lp_with_args)
-    assert not torch.equal(lp_no_args, sine_no_args)
-    assert not torch.equal(lp_no_args, sine_with_args)
-    assert not torch.equal(lp_with_args, sine_no_args)
-    assert not torch.equal(lp_with_args, sine_with_args)
     # learned temp embedding
 
-    lt_no_args = Embedding("temp", "learned")(times)
+    lt_no_args = Embedding("temp", "learned", 128)
 
     lt_args = {"emb_num": 100}
 
-    lt_with_args = Embedding("temp", "learned", **lt_args)(times)
-
-    assert not torch.equal(lt_no_args, lt_with_args)
-
-    assert not torch.equal(lt_no_args, lp_no_args)
-    assert not torch.equal(lt_no_args, lp_with_args)
-
-    assert not torch.equal(lt_no_args, sine_no_args)
-    assert not torch.equal(lt_no_args, sine_with_args)
-
-    assert not torch.equal(lt_with_args, lp_no_args)
-    assert not torch.equal(lt_with_args, lp_with_args)
-
-    assert not torch.equal(lt_with_args, sine_no_args)
-    assert not torch.equal(lt_with_args, sine_with_args)
+    lt_with_args = Embedding("temp", "learned", 128, **lt_args)
+    assert lt_no_args.lookup.weight.shape != lt_with_args.lookup.weight.shape
 
 
 def test_transformer_encoder():

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -11,7 +11,8 @@ from omegaconf import OmegaConf, DictConfig
 from biogtr.config import Config
 from biogtr.training.train import main
 
-# todo: add named tensor tests
+# TODO: add named tensor tests
+# TODO: use temp dir and cleanup after tests (https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html)
 
 
 def test_asso_loss():


### PR DESCRIPTION
* refactor how we initialize and use embeddings:
  * getting rid of `**kwargs`
  * initialize in params in `__init__`
  * introduce `type` and `mode` params to initialize correct embedding
  * wrap embedding computation function in `forward`
  * adapt embedding init based on refactor, and separate embeddings into pos and temp in transformer class
  * use embedding forward to compute embedding and simplify embedding computation
 
* get rid of redundant args in transformer and get rid of redundant args in GTR class



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced flexibility and clarity in model initialization parameters.
	- Improved handling and computation of embeddings, including updates based on metadata.

- **Tests**
	- Introduced and updated test functions for various model configurations and logic.

- **Documentation**
	- Updated configuration files to improve structure and clarity, separating modes and updating keys/values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->