### PR TITLE
Randomize instance order and crop

### DIFF
--- a/biogtr/datasets/cell_tracking_dataset.py
+++ b/biogtr/datasets/cell_tracking_dataset.py
@@ -74,16 +74,17 @@ class CellTrackingDataset(BaseDataset):
         self.clip_length = clip_length
         self.crop_size = crop_size
         self.padding = padding
-        self.mode = mode
+        self.mode = mode.lower()
         self.n_chunks = n_chunks
         self.seed = seed
 
         # if self.seed is not None:
         #     np.random.seed(self.seed)
 
-        self.augmentations = (
-            data_utils.build_augmentations(augmentations) if augmentations else None
-        )
+        if augmentations and self.mode == "train":
+            self.augmentations = data_utils.build_augmentations(augmentations)
+        else:
+            self.augmentations = None
 
         if gt_list is not None:
             self.gt_list = [
@@ -200,6 +201,9 @@ class CellTrackingDataset(BaseDataset):
                         crop=crop,
                     )
                 )
+
+            if self.mode == "train":
+                np.random.shuffle(instances)
 
             frames.append(
                 Frame(

--- a/biogtr/datasets/data_utils.py
+++ b/biogtr/datasets/data_utils.py
@@ -113,7 +113,7 @@ def pose_bbox(points: np.ndarray, bbox_size: Union[tuple[int], int]) -> torch.Te
     """Calculate bbox around instance pose.
 
     Args:
-        instance: a labeled instance in a frame,
+        points: an np array of shape nodes x 2,
         bbox_size: size of bbox either an int indicating square bbox or in (x,y)
 
     Returns:
@@ -122,16 +122,8 @@ def pose_bbox(points: np.ndarray, bbox_size: Union[tuple[int], int]) -> torch.Te
     if isinstance(bbox_size, int):
         bbox_size = (bbox_size, bbox_size)
     # print(points)
-    minx = np.nanmin(points[:, 0], axis=-1)
-    miny = np.nanmin(points[:, -1], axis=-1)
-    minpoints = np.array([minx, miny]).T
 
-    maxx = np.nanmax(points[:, 0], axis=-1)
-    maxy = np.nanmax(points[:, -1], axis=-1)
-    maxpoints = np.array([maxx, maxy]).T
-
-    c = (minpoints + maxpoints) / 2
-
+    c = np.nanmean(points, axis=0)
     bbox = torch.Tensor(
         [
             c[-1] - bbox_size[-1] / 2,

--- a/biogtr/datasets/microscopy_dataset.py
+++ b/biogtr/datasets/microscopy_dataset.py
@@ -69,16 +69,16 @@ class MicroscopyDataset(BaseDataset):
         self.clip_length = clip_length
         self.crop_size = crop_size
         self.padding = padding
-        self.mode = mode
+        self.mode = mode.lower()
         self.n_chunks = n_chunks
         self.seed = seed
 
         # if self.seed is not None:
         #     np.random.seed(self.seed)
-
-        self.augmentations = (
-            data_utils.build_augmentations(augmentations) if augmentations else None
-        )
+        if augmentations and self.mode == "train":
+            self.augmentations = data_utils.build_augmentations(augmentations)
+        else:
+            self.augmentations = None
 
         if source.lower() == "trackmate":
             parser = data_utils.parse_trackmate
@@ -190,6 +190,9 @@ class MicroscopyDataset(BaseDataset):
                         crop=crop,
                     )
                 )
+
+            if self.mode == "train":
+                np.random.shuffle(instances)
 
             frames.append(
                 Frame(


### PR DESCRIPTION
As noted in #31, the model may be overfitting to the order in which the instance reid_features are fed into the model. Especially with our dataset logic in microscopy where we just iterate over the track ids this could be especially problematic. Thus in this PR we:
* shuffle instances in training mode.

We also add a functionality for random anchor selection when we crop to test if we can generalize the model to missing anchors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new attributes for managing centroid and anchor data, enhancing data structuring capabilities.
  - Implemented conditional data augmentation and shuffling for training mode in various datasets to optimize model training.
  
- **Enhancements**
  - Improved bounding box calculation using a more accurate centering technique.
  
- **Bug Fixes**
  - Standardized `mode` attribute handling by converting it to lowercase across multiple dataset classes to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->