### PR TITLE
Multi anchor crop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,8 @@ dmypy.json
 # lightning
 lightning_logs
 outputs
+logs
+models
 
 # vscode
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -133,7 +133,7 @@ dmypy.json
 lightning_logs
 outputs
 logs
-models
+*.ckpt
 
 # vscode
 .vscode

--- a/biogtr/data_structures.py
+++ b/biogtr/data_structures.py
@@ -635,7 +635,7 @@ class Frame:
         return self
 
     def to_slp(
-        self, track_lookup: dict[int : sio.Track] = {}
+        self, track_lookup: dict[int, sio.Track] = {}
     ) -> tuple[sio.LabeledFrame, dict[int, sio.Track]]:
         """Convert Frame to sleap_io.LabeledFrame object.
 

--- a/biogtr/data_structures.py
+++ b/biogtr/data_structures.py
@@ -575,7 +575,7 @@ class Frame:
         except ValueError:
             self._video = vid_file
         if img_shape is None:
-            self._img_shape=torch.tensor([0,0,0])
+            self._img_shape = torch.tensor([0, 0, 0])
         elif isinstance(img_shape, torch.Tensor):
             self._img_shape = img_shape
         else:

--- a/biogtr/datasets/sleap_dataset.py
+++ b/biogtr/datasets/sleap_dataset.py
@@ -192,15 +192,21 @@ class SleapDataset(BaseDataset):
 
             try:
                 img = vid_reader.get_data(frame_ind)
-                if len(img.shape) == 2:
-                    img = img.expand_dims(0)
-                h, w, c = img.shape
-                if len(img.shape) == 2:
-                    img = img.expand_dims(0)
-                h, w, c = img.shape
             except IndexError as e:
                 print(f"Could not read frame {frame_ind} from {video_name} due to {e}")
                 continue
+
+            if len(img.shape) == 2:
+                img = img.expand_dims(-1)
+            h, w, c = img.shape
+
+            if c == 1:
+                img = np.concatenate(
+                    [img, img, img], axis=-1
+                )  # convert to grayscale to rgb
+
+            if np.issubdtype(img.dtype, np.integer):  # convert int to float
+                img = img.astype(np.float32) / 255
 
             for instance in lf:
                 if instance.track is not None:

--- a/biogtr/datasets/sleap_dataset.py
+++ b/biogtr/datasets/sleap_dataset.py
@@ -43,15 +43,11 @@ class SleapDataset(BaseDataset):
                         * a string indicating a single node to center crops around
                         * a list of skeleton node names to be used as the center of crops
                         * an int indicating the number of anchors to randomly select
-            anchors: One of:
-                        * a string indicating a single node to center crops around
-                        * a list of skeleton node names to be used as the center of crops
-                        * an int indicating the number of anchors to randomly select
-            If unavailable then crop around the midpoint between all visible anchors.
+                    If unavailable then crop around the midpoint between all visible anchors.
             chunk: whether or not to chunk the dataset into batches
             clip_length: the number of frames in each chunk
             mode: `train` or `val`. Determines whether this dataset is used for
-                training or validation. Currently doesn't affect dataset logic
+                training or validation.
             augmentations: An optional dict mapping augmentations to parameters. The keys
                 should map directly to augmentation classes in albumentations. Example:
                     augmentations = {
@@ -85,18 +81,6 @@ class SleapDataset(BaseDataset):
         self.mode = mode.lower()
         self.n_chunks = n_chunks
         self.seed = seed
-
-        if isinstance(anchors, int):
-            self.anchors = anchors
-        elif isinstance(anchors, str):
-            self.anchors = [anchors.lower()]
-        else:
-            self.anchors = [anchor.lower() for anchor in anchors]
-
-        if (
-            isinstance(self.anchors, list) and len(self.anchors) == 0
-        ) or self.anchors == 0:
-            raise ValueError(f"Must provide at least one anchor but got {self.anchors}")
 
         if isinstance(anchors, int):
             self.anchors = anchors

--- a/biogtr/datasets/sleap_dataset.py
+++ b/biogtr/datasets/sleap_dataset.py
@@ -23,7 +23,7 @@ class SleapDataset(BaseDataset):
         video_files: list[str],
         padding: int = 5,
         crop_size: int = 128,
-        anchor: str = "",
+        anchors: Union[int, list[str], str] = "",
         chunk: bool = True,
         clip_length: int = 500,
         mode: str = "train",
@@ -39,7 +39,10 @@ class SleapDataset(BaseDataset):
             video_files: a list of paths to video files
             padding: amount of padding around object crops
             crop_size: the size of the object crops
-            anchor: the name of the anchor keypoint to be used as centroid for cropping.
+            anchors: One of:
+                        * a string indicating a single node to center crops around
+                        * a list of skeleton node names to be used as the center of crops
+                        * an int indicating the number of anchors to randomly select
             If unavailable then crop around the midpoint between all visible anchors.
             chunk: whether or not to chunk the dataset into batches
             clip_length: the number of frames in each chunk
@@ -78,7 +81,19 @@ class SleapDataset(BaseDataset):
         self.mode = mode.lower()
         self.n_chunks = n_chunks
         self.seed = seed
-        self.anchor = anchor.lower()
+
+        if isinstance(anchors, int):
+            self.anchors = anchors
+        elif isinstance(anchors, str):
+            self.anchors = [anchors.lower()]
+        else:
+            self.anchors = [anchor.lower() for anchor in anchors]
+
+        if (
+            isinstance(self.anchors, list) and len(self.anchors) == 0
+        ) or self.anchors == 0:
+            raise ValueError(f"Must provide at least one anchor but got {self.anchors}")
+
         self.verbose = verbose
 
         # if self.seed is not None:
@@ -161,6 +176,9 @@ class SleapDataset(BaseDataset):
 
             try:
                 img = vid_reader.get_data(frame_ind)
+                if len(img.shape) == 2:
+                    img = img.expand_dims(0)
+                h, w, c = img.shape
             except IndexError as e:
                 print(f"Could not read frame {frame_ind} from {video_name} due to {e}")
                 continue
@@ -247,41 +265,66 @@ class SleapDataset(BaseDataset):
                 pose = shown_poses[j]
 
                 """Check for anchor"""
-                if self.anchor == "random":
-                    anchors = list(pose.keys()) + ["midpoint"]
-                    anchor = np.random.choice(anchors)
-                elif self.anchor in pose:
-                    anchor = self.anchor
+                crops = []
+                boxes = []
+                centroids = {}
+
+                if isinstance(self.anchors, int):
+                    anchors_to_choose = list(pose.keys()) + ["midpoint"]
+                    anchors = np.random.choice(anchors_to_choose, self.anchors)
                 else:
-                    if self.verbose:
-                        warnings.warn(
-                            f"{self.anchor} not in {[key for key in pose.keys()]}! Defaulting to midpoint"
-                        )
-                    anchor = "midpoint"
+                    anchors = self.anchors
 
-                if anchor != "midpoint":
-                    centroid = pose[anchor]
+                for anchor in anchors:
+                    if anchor == "midpoint" or anchor == "centroid":
+                        centroid = np.nanmean(np.array(list(pose.values())), axis=0)
 
-                    if np.isnan(centroid).any():
+                    elif anchor in pose:
+                        centroid = np.array(pose[anchor])
+                        if np.isnan(centroid).any():
+                            centroid = np.array([None, None])
+
+                    elif anchor not in pose and len(anchors) == 1:
                         anchor = "midpoint"
                         centroid = np.nanmean(np.array(list(pose.values())), axis=0)
-                else:
-                    # print(f'{self.anchor} not an available option amongst {pose.keys()}. Using midpoint')
-                    centroid = np.nanmean(np.array(list(pose.values())), axis=0)
 
-                bbox = data_utils.pad_bbox(
-                    data_utils.get_bbox(centroid, self.crop_size),
-                    padding=self.padding,
-                )
+                    else:
+                        centroid = np.array([np.nan, np.nan])
 
-                crop = data_utils.crop_bbox(img, bbox)
+                    if np.isnan(centroid).all():
+                        bbox = torch.tensor([np.nan, np.nan, np.nan, np.nan])
+                    else:
+                        bbox = data_utils.pad_bbox(
+                            data_utils.get_bbox(centroid, self.crop_size),
+                            padding=self.padding,
+                        )
+
+                    if bbox.isnan().all():
+                        crop = torch.zeros(
+                            c,
+                            self.crop_size + 2 * self.padding,
+                            self.crop_size + 2 * self.padding,
+                            dtype=img.dtype,
+                        )
+                    else:
+                        crop = data_utils.crop_bbox(img, bbox)
+
+                    crops.append(crop)
+                    centroids[anchor] = centroid
+                    boxes.append(bbox)
+
+                if len(crops) > 0:
+                    crops = torch.concat(crops, dim=0)
+
+                if len(boxes) > 0:
+                    boxes = torch.stack(boxes, dim=0)
 
                 instance = Instance(
                     gt_track_id=gt_track_ids[j],
                     pred_track_id=-1,
-                    crop=crop,
-                    centroid={anchor: centroid},
-                    bbox=bbox,
+                    crop=crops,
+                    centroid=centroids,
+                    bbox=boxes,
                     skeleton=skeleton,
                     pose=poses[j],
                     point_scores=point_scores[j],

--- a/biogtr/inference/post_processing.py
+++ b/biogtr/inference/post_processing.py
@@ -108,7 +108,9 @@ def weight_iou(
         assert last_ious is not None, "Need `last_ious` to weight traj_score by `IOU`"
         if method.lower() == "mult":
             weights = torch.abs(last_ious - asso_output)
-            asso_output = asso_output + (weights * last_ious)
+            weighted_iou = weights * last_ious
+            weighted_iou = torch.nan_to_num(weighted_iou, 0)
+            asso_output = asso_output + weighted_iou
         elif method.lower() == "max":
             asso_output = torch.max(asso_output, last_ious)
         else:

--- a/biogtr/models/__init__.py
+++ b/biogtr/models/__init__.py
@@ -1,6 +1,7 @@
 """Model architectures and layers."""
 
-from .attention_head import MLP, ATTWeightHead
+from .attention_head import ATTWeightHead
+
 from .embedding import Embedding
 from .transformer import Transformer
 from .visual_encoder import VisualEncoder

--- a/biogtr/models/attention_head.py
+++ b/biogtr/models/attention_head.py
@@ -1,66 +1,9 @@
 """Module containing different components of multi-head attention heads."""
 
 import torch
-import torch.nn.functional as F
+from biogtr.models.mlp import MLP
 
 # todo: add named tensors
-
-
-class MLP(torch.nn.Module):
-    """Multi-Layer Perceptron (MLP) module."""
-
-    def __init__(
-        self,
-        input_dim: int,
-        hidden_dim: int,
-        output_dim: int,
-        num_layers: int,
-        dropout: float = 0.0,
-    ):
-        """Initialize MLP.
-
-        Args:
-            input_dim: Dimensionality of the input features.
-            hidden_dim: Number of units in the hidden layers.
-            output_dim: Dimensionality of the output features.
-            num_layers: Number of hidden layers.
-            dropout: Dropout probability.
-        """
-        super().__init__()
-
-        self.num_layers = num_layers
-        self.dropout = dropout
-
-        if self.num_layers > 0:
-            h = [hidden_dim] * (num_layers - 1)
-            self.layers = torch.nn.ModuleList(
-                [
-                    torch.nn.Linear(n, k)
-                    for n, k in zip([input_dim] + h, h + [output_dim])
-                ]
-            )
-            if self.dropout > 0.0:
-                self.dropouts = torch.nn.ModuleList(
-                    [torch.nn.Dropout(dropout) for _ in range(self.num_layers - 1)]
-                )
-        else:
-            self.layers = []
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Forward pass of the MLP.
-
-        Args:
-            x: Input tensor of shape (batch_size, num_instances, input_dim).
-
-        Returns:
-            Output tensor of shape (batch_size, num_instances, output_dim).
-        """
-        for i, layer in enumerate(self.layers):
-            x = F.relu(layer(x)) if i < self.num_layers - 1 else layer(x)
-            if i < self.num_layers - 1 and self.dropout > 0.0:
-                x = self.dropouts[i](x)
-
-        return x
 
 
 class ATTWeightHead(torch.nn.Module):
@@ -81,8 +24,8 @@ class ATTWeightHead(torch.nn.Module):
         """
         super().__init__()
 
-        self.q_proj = MLP(feature_dim, feature_dim, feature_dim, num_layers, dropout)
-        self.k_proj = MLP(feature_dim, feature_dim, feature_dim, num_layers, dropout)
+        self.q_proj = MLP(feature_dim, feature_dim, num_layers, dropout)
+        self.k_proj = MLP(feature_dim, feature_dim, num_layers, dropout)
 
     def forward(
         self,

--- a/biogtr/models/attention_head.py
+++ b/biogtr/models/attention_head.py
@@ -24,8 +24,8 @@ class ATTWeightHead(torch.nn.Module):
         """
         super().__init__()
 
-        self.q_proj = MLP(feature_dim, feature_dim, num_layers, dropout)
-        self.k_proj = MLP(feature_dim, feature_dim, num_layers, dropout)
+        self.q_proj = MLP(feature_dim, feature_dim, feature_dim, num_layers, dropout)
+        self.k_proj = MLP(feature_dim, feature_dim, feature_dim, num_layers, dropout)
 
     def forward(
         self,

--- a/biogtr/models/embedding.py
+++ b/biogtr/models/embedding.py
@@ -73,7 +73,7 @@ class Embedding(torch.nn.Module):
         if self.normalize and self.scale is None:
             self.scale = 2 * math.pi
 
-        if self.emb_type == "pos" and mlp_cfg is not None:
+        if self.emb_type == "pos" and mlp_cfg is not None and mlp_cfg["num_layers"] > 0:
             if self.mode == "fixed":
                 self.mlp = MLP(
                     input_dim=n_points * self.features,

--- a/biogtr/models/global_tracking_transformer.py
+++ b/biogtr/models/global_tracking_transformer.py
@@ -13,8 +13,7 @@ class GlobalTrackingTransformer(nn.Module):
 
     def __init__(
         self,
-        encoder_model: str = "resnet18",
-        encoder_cfg: dict = {},
+        encoder_cfg: dict = None,
         d_model: int = 1024,
         nhead: int = 8,
         num_encoder_layers: int = 6,
@@ -33,9 +32,8 @@ class GlobalTrackingTransformer(nn.Module):
         """Initialize GTR.
 
         Args:
-            encoder_model: Name of the CNN architecture to use (e.g. "resnet18", "resnet50").
             encoder_cfg: Dictionary of arguments to pass to the CNN constructor,
-                e.g: `cfg = {"weights": "ResNet18_Weights.DEFAULT"}`
+                e.g: `cfg = {model_name: "resnet18", pretrained: False, "in_chans": 3}`
             d_model: The number of features in the encoder/decoder inputs.
             nhead: The number of heads in the transfomer encoder/decoder.
             num_encoder_layers: The number of encoder-layers in the encoder.
@@ -60,7 +58,10 @@ class GlobalTrackingTransformer(nn.Module):
         """
         super().__init__()
 
-        self.visual_encoder = VisualEncoder(encoder_model, encoder_cfg, d_model)
+        if encoder_cfg is not None:
+            self.visual_encoder = VisualEncoder(d_model=d_model, **encoder_cfg)
+        else:
+            self.visual_encoder = VisualEncoder(d_model=d_model)
 
         self.transformer = Transformer(
             d_model=d_model,

--- a/biogtr/models/global_tracking_transformer.py
+++ b/biogtr/models/global_tracking_transformer.py
@@ -33,7 +33,7 @@ class GlobalTrackingTransformer(nn.Module):
 
         Args:
             encoder_cfg: Dictionary of arguments to pass to the CNN constructor,
-                e.g: `cfg = {model_name: "resnet18", pretrained: False, "in_chans": 3}`
+                e.g: `cfg = {"model_name": "resnet18", "pretrained": False, "in_chans": 3}`
             d_model: The number of features in the encoder/decoder inputs.
             nhead: The number of heads in the transfomer encoder/decoder.
             num_encoder_layers: The number of encoder-layers in the encoder.

--- a/biogtr/models/mlp.py
+++ b/biogtr/models/mlp.py
@@ -1,0 +1,60 @@
+"""Multi-Layer Perceptron (MLP) module."""
+
+import torch
+
+
+class MLP(torch.nn.Module):
+    """Multi-layer perceptron class."""
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        output_dim: int,
+        num_layers: int,
+        dropout: float = 0.0,
+    ):
+        """Initialize MLP.
+
+        Args:
+            input_dim: Dimensionality of the input features.
+            hidden_dim: Number of units in the hidden layers.
+            output_dim: Dimensionality of the output features.
+            num_layers: Number of hidden layers.
+            dropout: Dropout probability.
+        """
+        super().__init__()
+
+        self.num_layers = num_layers
+        self.dropout = dropout
+        self.hidden_dim = hidden_dim
+        self.output_dim = output_dim
+
+        if self.num_layers > 0:
+            self.layers = [torch.nn.LazyLinear(hidden_dim)]
+            self.dropouts = [torch.nn.Dropout(dropout)]
+            for i in range(num_layers):
+                self.layers.append(torch.nn.Linear(hidden_dim, hidden_dim))
+                self.dropouts.append(torch.nn.Dropout(dropout))
+            self.layers.append(torch.nn.Linear(hidden_dim, output_dim))
+            self.dropouts.append(torch.nn.Dropout(0.0))
+
+            self.layers = torch.nn.ModuleList(self.layers)
+            self.dropouts = torch.nn.ModuleList(self.dropouts)
+        else:
+            self.layers = torch.nn.ModuleList([])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass of the MLP.
+
+        Args:
+            x: Input tensor of shape (batch_size, num_instances, input_dim).
+
+        Returns:
+            Output tensor of shape (batch_size, num_instances, output_dim).
+        """
+        for i in range(len(self.layers) - 1):
+            x = torch.nn.functional.relu(self.layers[i](x))
+            x = self.dropouts[i](x)
+        x = self.layers[-1](x)
+
+        return x

--- a/biogtr/models/model_utils.py
+++ b/biogtr/models/model_utils.py
@@ -22,13 +22,13 @@ def get_boxes_times(frames: List[Frame]) -> Tuple[torch.Tensor, torch.Tensor]:
 
     for fidx, frame in enumerate(frames):
         bbox = frame.get_bboxes().clone()
-        bbox[:, [0, 2]] /= w
-        bbox[:, [1, 3]] /= h
+        bbox[:, :, [0, 2]] /= w
+        bbox[:, :, [1, 3]] /= h
 
         boxes.append(bbox)
         times.append(torch.full((bbox.shape[0],), fidx))
 
-    boxes = torch.cat(boxes, dim=0)  # N x 4
+    boxes = torch.cat(boxes, dim=0)  # N, n_anchors, 4
     times = torch.cat(times, dim=0).to(boxes.device)  # N
     return boxes, times
 

--- a/biogtr/models/transformer.py
+++ b/biogtr/models/transformer.py
@@ -171,6 +171,7 @@ class Transformer(torch.nn.Module):
         embeddings_dict = {"pos": None, "temp": None}
         # print(f'T: {window_length}; N: {total_instances}; N_t: {instances_per_frame} n_reid: {reid_features.shape}')
         pred_box, pred_time = get_boxes_times(frames)  # total_instances, 4
+        pred_box = torch.nan_to_num(pred_box, -1.0)
 
         temp_emb = self.temp_emb(pred_time / window_length)
         if self.return_embedding:

--- a/biogtr/models/transformer.py
+++ b/biogtr/models/transformer.py
@@ -132,8 +132,12 @@ class Transformer(torch.nn.Module):
     def _reset_parameters(self):
         """Initialize model weights from xavier distribution."""
         for p in self.parameters():
-            if p.dim() > 1:
-                nn.init.xavier_uniform_(p)
+            if not torch.nn.parameter.is_lazy(p) and p.dim() > 1:
+                try:
+                    nn.init.xavier_uniform_(p)
+                except ValueError as e:
+                    print(f"Failed Trying to initialize {p}")
+                    raise (e)
 
     def forward(
         self, frames: list[Frame], query_frame: int = None

--- a/biogtr/models/visual_encoder.py
+++ b/biogtr/models/visual_encoder.py
@@ -2,6 +2,7 @@
 
 from typing import Tuple
 import torch
+import torchvision
 import timm
 import torch.nn.functional as F
 
@@ -22,7 +23,7 @@ class VisualEncoder(torch.nn.Module):
         model_name: str = "resnet18",
         d_model: int = 512,
         in_chans: int = 3,
-        pretrained: bool = False,
+        backend="timm",
         **kwargs,
     ):
         """Initialize Visual Encoder.
@@ -31,29 +32,84 @@ class VisualEncoder(torch.nn.Module):
             model_name (str): Name of the CNN architecture to use (e.g. "resnet18", "resnet50").
             d_model (int): Output embedding dimension.
             in_chans: the number of input channels of the image.
-            pretrained: whether or not to use pretrained weights from hugging_face
-            kwargs: see `timm.create_model` for kwargs.
+            backend: Which model backend to use. One of {"timm", "torchvision"}
+            kwargs: see `timm.create_model` and `torchvision.models.resnetX` for kwargs.
         """
         super().__init__()
 
         self.model_name = model_name.lower()
         self.d_model = d_model
+        self.backend = backend
         if in_chans == 1:
             self.in_chans = 3
         else:
             self.in_chans = in_chans
 
-        self.feature_extractor = timm.create_model(
+        self.feature_extractor = self.select_feature_extractor(
             model_name=self.model_name,
             in_chans=self.in_chans,
-            pretrained=pretrained,
-            num_classes=0,
+            backend=self.backend,
             **kwargs,
         )
 
         self.out_layer = torch.nn.Linear(
             self.encoder_dim(self.feature_extractor), self.d_model
         )
+
+    def select_feature_extractor(
+        self, model_name: str, in_chans: int, backend: str, **kwargs
+    ) -> torch.nn.Module:
+        """Select the appropriate feature extractor based on config.
+
+        Args:
+            model_name (str): Name of the CNN architecture to use (e.g. "resnet18", "resnet50").
+            in_chans: the number of input channels of the image.
+            backend: Which model backend to use. One of {"timm", "torchvision"}
+            kwargs: see `timm.create_model` and `torchvision.models.resnetX` for kwargs.
+
+        Returns:
+            a CNN encoder based on the config and backend selected.
+        """
+        if "timm" in backend.lower():
+            feature_extractor = timm.create_model(
+                model_name=self.model_name,
+                in_chans=self.in_chans,
+                num_classes=0,
+                **kwargs,
+            )
+        elif "torch" in backend.lower():
+            if model_name.lower() == "resnet18":
+                feature_extractor = torchvision.models.resnet18(**kwargs)
+
+            elif model_name.lower() == "resnet50":
+                feature_extractor = torchvision.models.resnet50(**kwargs)
+
+            else:
+                raise ValueError(
+                    f"Only `[resnet18, resnet50]` are available when backend is {backend}. Found {model_name}"
+                )
+            feature_extractor = torch.nn.Sequential(
+                *list(feature_extractor.children())[:-1]
+            )
+            input_layer = feature_extractor[0]
+            if in_chans != 3:
+                feature_extractor[0] = torch.nn.Conv2d(
+                    in_channels=in_chans,
+                    out_channels=input_layer.out_channels,
+                    kernel_size=input_layer.kernel_size,
+                    stride=input_layer.stride,
+                    padding=input_layer.padding,
+                    dilation=input_layer.dilation,
+                    groups=input_layer.groups,
+                    bias=input_layer.bias,
+                    padding_mode=input_layer.padding_mode,
+                )
+
+        else:
+            raise ValueError(
+                f"Only ['timm', 'torch'] backends are available! Found {backend}."
+            )
+        return feature_extractor
 
     def encoder_dim(self, model: torch.nn.Module) -> int:
         """Compute dummy forward pass of encoder model and get embedding dimension.
@@ -65,7 +121,7 @@ class VisualEncoder(torch.nn.Module):
             The embedding dimension size.
         """
         _ = model.eval()
-        dummy_output = model(torch.randn(1, self.in_chans, 224, 224))
+        dummy_output = model(torch.randn(1, self.in_chans, 224, 224)).squeeze()
         _ = model.train()  # to be safe
         return dummy_output.shape[-1]
 

--- a/biogtr/models/visual_encoder.py
+++ b/biogtr/models/visual_encoder.py
@@ -2,7 +2,7 @@
 
 from typing import Tuple
 import torch
-import torchvision
+import timm
 import torch.nn.functional as F
 
 # import timm
@@ -17,51 +17,40 @@ class VisualEncoder(torch.nn.Module):
     Currently CNN only.
     """
 
-    def __init__(self, model_name: str, cfg: dict, d_model: int = 512):
+    def __init__(
+        self,
+        model_name: str = "resnet18",
+        d_model: int = 512,
+        in_chans: int = 3,
+        pretrained: bool = False,
+        **kwargs,
+    ):
         """Initialize Visual Encoder.
 
         Args:
             model_name (str): Name of the CNN architecture to use (e.g. "resnet18", "resnet50").
-            cfg (dict): Dictionary of arguments to pass to the CNN constructor,
-                e.g: `cfg = {"weights": "ResNet18_Weights.DEFAULT"}`
             d_model (int): Output embedding dimension.
+            in_chans: the number of input channels of the image.
+            pretrained: whether or not to use pretrained weights from hugging_face
+            kwargs: see `timm.create_model` for kwargs.
         """
         super().__init__()
 
-        self.model_name = model_name
+        self.model_name = model_name.lower()
         self.d_model = d_model
+        if in_chans == 1:
+            self.in_chans = 3
+        else:
+            self.in_chans = in_chans
 
-        self.feature_extractor, out_dim = self.select_feature_extractor(model_name, cfg)
-
-        self.feature_extractor = torch.nn.Sequential(
-            *list(self.feature_extractor.children())[:-1]
+        self.feature_extractor = timm.create_model(
+            model_name=self.model_name,
+            pretrained=pretrained,
+            in_chans=self.in_chans,
+            num_classes=0,
         )
 
-        self.out_layer = torch.nn.Linear(out_dim, d_model)
-
-    def select_feature_extractor(
-        self, model_name: str, cfg: dict
-    ) -> Tuple[torch.nn.Module, int]:
-        """Get feature extractor based on name and config.
-
-        Args:
-            model_name (str): Name of the CNN architecture to use (e.g. "resnet18", "resnet50").
-            cfg (dict): Dictionary of arguments to pass to the CNN constructor,
-                e.g: `cfg = {"weights": "ResNet18_Weights.DEFAULT"}`
-
-        Returns:
-            The CNN feature extractor and output dimension for the given CNN architecture.
-        """
-        if model_name == "resnet18":
-            model = torchvision.models.resnet18(**cfg)
-            out_dim = 512
-        elif model_name == "resnet50":
-            model = torchvision.models.resnet50(**cfg)
-            out_dim = 2048
-        else:
-            raise ValueError(f"{model_name} model not found.")
-
-        return model, out_dim
+        self.out_layer = torch.nn.LazyLinear(d_model)
 
     def forward(self, img: torch.Tensor) -> torch.Tensor:
         """Forward pass of feature extractor to get feature vector.
@@ -75,7 +64,6 @@ class VisualEncoder(torch.nn.Module):
         # If grayscale, tile the image to 3 channels.
         if img.shape[1] == 1:
             img = img.repeat([1, 3, 1, 1])  # (B, nc=3, H, W)
-
         # Extract image features
         feats = self.feature_extractor(
             img

--- a/biogtr/training/configs/base.yaml
+++ b/biogtr/training/configs/base.yaml
@@ -14,12 +14,10 @@ model:
   dropout_attn_head: 0.1
   embedding_meta: 
     pos:
-      mode: "learned"
-      emb_num: 16
-      over_boxes: false
+        mode: "fixed"
+        normalize: true
     temp:
-      mode: "learned"
-      emb_num: 16
+        mode: "fixed"
   return_embedding: False
   decoder_self_attn: False
 

--- a/biogtr/training/losses.py
+++ b/biogtr/training/losses.py
@@ -52,6 +52,7 @@ class AssoLoss(nn.Module):
 
         # for now set equal since detections are fixed
         pred_box, pred_time = get_boxes_times(frames)
+        pred_box = torch.nanmean(pred_box, axis=1)
         target_box, target_time = pred_box, pred_time
 
         # todo: we should maybe reconsider how we label gt instances. The second

--- a/environment.yml
+++ b/environment.yml
@@ -29,3 +29,4 @@ dependencies:
     - motmetrics
     - seaborn
     - wandb
+    - timm

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -28,3 +28,4 @@ dependencies:
     - motmetrics
     - seaborn
     - wandb
+    - timm

--- a/environment_osx-arm64.yml
+++ b/environment_osx-arm64.yml
@@ -18,3 +18,4 @@ dependencies:
   - pip
   - pip:
     - "--editable=.[dev]"
+    - timm

--- a/tests/configs/base.yaml
+++ b/tests/configs/base.yaml
@@ -13,13 +13,11 @@ model:
   num_layers_attn_head: 2
   dropout_attn_head: 0.1
   embedding_meta: 
-    pos: 
-      mode: 'learned'
-      emb_num: 16
-      over_boxes: False
+    pos:
+        mode: "fixed"
+        normalize: true
     temp:
-      mode: 'learned'
-      emb_num: 16
+        mode: "fixed"
 
   return_embedding: False
   decoder_self_attn: False
@@ -65,7 +63,7 @@ dataset:
   train_dataset:
     slp_files: ['tests/data/sleap/two_flies.slp']
     video_files: ['tests/data/sleap/two_flies.mp4']
-    anchor: "thorax"
+    anchors: "thorax"
     padding: 5
     crop_size: 128
     chunk: true
@@ -74,7 +72,7 @@ dataset:
   val_dataset:
     slp_files: ['tests/data/sleap/two_flies.slp']
     video_files: ['tests/data/sleap/two_flies.mp4']
-    anchor: "thorax"
+    anchors: "thorax"
     padding: 5
     crop_size: 128
     chunk: True
@@ -83,7 +81,7 @@ dataset:
   test_dataset:
     slp_files: ['tests/data/sleap/two_flies.slp']
     video_files: ['tests/data/sleap/two_flies.mp4']
-    anchor: "thorax"
+    anchors: "thorax"
     padding: 5
     crop_size: 128
     chunk: True

--- a/tests/configs/base.yaml
+++ b/tests/configs/base.yaml
@@ -1,7 +1,9 @@
 model:
   ckpt_path: null
-  encoder_model: "resnet18"
-  encoder_cfg: {}
+  encoder_cfg:
+    model_name: "resnet18"
+    in_chans: 3
+    pretrained: False
   d_model: 512
   nhead: 8
   num_encoder_layers: 1

--- a/tests/test_data_structures.py
+++ b/tests/test_data_structures.py
@@ -10,7 +10,7 @@ def test_instance():
 
     gt_track_id = 0
     pred_track_id = 0
-    bbox = torch.randn((1, 4))
+    bbox = torch.randn((1, 1, 4))
     crop = torch.randn((1, 3, 128, 128))
     features = torch.randn((1, 64))
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -49,6 +49,7 @@ def test_sleap_dataset(two_flies):
         crop_size=128,
         chunk=True,
         clip_length=clip_length,
+        anchors="thorax",
     )
 
     ds_length = len(train_ds)
@@ -58,6 +59,52 @@ def test_sleap_dataset(two_flies):
     assert len(instances) == clip_length
     assert len(instances[0].get_gt_track_ids()) == 2
     assert len(instances[0].get_gt_track_ids()) == instances[0].num_detected
+    assert instances[0].get_crops().shape[1] == 3
+
+    train_ds = SleapDataset(
+        slp_files=[two_flies[0]],
+        video_files=[two_flies[1]],
+        crop_size=128,
+        chunk=True,
+        clip_length=clip_length,
+        anchors=["thorax", "head"],
+    )
+
+    ds_length = len(train_ds)
+
+    instances = next(iter(train_ds))
+
+    assert instances[0].get_crops().shape[1] == 6
+
+    train_ds = SleapDataset(
+        slp_files=[two_flies[0]],
+        video_files=[two_flies[1]],
+        crop_size=128,
+        chunk=True,
+        clip_length=clip_length,
+        anchors=1,
+    )
+
+    ds_length = len(train_ds)
+
+    instances = next(iter(train_ds))
+
+    assert instances[0].get_crops().shape[1] == 3
+
+    train_ds = SleapDataset(
+        slp_files=[two_flies[0]],
+        video_files=[two_flies[1]],
+        crop_size=128,
+        chunk=True,
+        clip_length=clip_length,
+        anchors=2,
+    )
+
+    ds_length = len(train_ds)
+
+    instances = next(iter(train_ds))
+
+    assert instances[0].get_crops().shape[1] == 6
 
     chunk_frac = 0.5
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -43,13 +43,10 @@ def test_tracker():
     }
 
     tracking_transformer = GlobalTrackingTransformer(
-        encoder_model="resnet18",
-        encoder_cfg={"weights": "ResNet18_Weights.DEFAULT"},
+        encoder_cfg={"model_name": "resnet18", "pretrained": False, "in_chans": 3},
         d_model=feats,
         num_encoder_layers=1,
         num_decoder_layers=1,
-        dim_feedforward=feats,
-        feature_dim_attn_head=feats,
         embedding_meta=embedding_meta,
         return_embedding=False,
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -175,6 +175,7 @@ def test_embedding_basic():
     assert not off_emb_boxes.any()
     assert not off_emb_times.any()
 
+
 def test_embedding_kwargs():
     """Test embedding config logic."""
 
@@ -221,6 +222,7 @@ def test_embedding_kwargs():
     lt_with_args = Embedding("temp", "learned", 128, **lt_args)
     assert lt_no_args.lookup.weight.shape != lt_with_args.lookup.weight.shape
 
+
 def test_multianchor_embedding():
     frames = 32
     objects = 10
@@ -234,7 +236,9 @@ def test_multianchor_embedding():
     times = torch.rand(size=(N,))
 
     fixed_emb = Embedding("pos", "fixed", features=features, n_mlp_layers=3)
-    learned_emb = Embedding("pos", "learned", features=features, n_mlp_layers=3, n_points=n_anchors)
+    learned_emb = Embedding(
+        "pos", "learned", features=features, n_mlp_layers=3, n_points=n_anchors
+    )
     assert not isinstance(fixed_emb.mlp, torch.nn.Identity)
     assert not isinstance(learned_emb.mlp, torch.nn.Identity)
 
@@ -250,7 +254,7 @@ def test_multianchor_embedding():
         _ = fixed_emb(boxes)
     with pytest.raises(RuntimeError):
         _ = learned_emb(boxes)
-    
+
 
 def test_transformer_encoder():
     """Test transformer encoder layer logic."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -49,17 +49,31 @@ def test_encoder():
     features = 512
     input_tensor = torch.rand(b, c, h, w)
 
-    for model_name, weights_name in [
-        ("resnet18", "ResNet18_Weights.DEFAULT"),
-        ("resnet50", "ResNet50_Weights.DEFAULT"),
-    ]:
-        cfg = {"weights": weights_name}
+    encoder = VisualEncoder(model_name="resnet18", in_chans=c, d_model=features)
 
-        encoder = VisualEncoder(model_name, cfg, features)
+    output = encoder(input_tensor)
 
-        output = encoder(input_tensor)
+    assert output.shape == (b, features)
 
-        assert output.shape == (b, features)
+    c = 3
+    input_tensor = torch.rand(b, c, h, w)
+
+    features = 128
+
+    encoder = VisualEncoder(model_name="resnet18", in_chans=c, d_model=features)
+
+    output = encoder(input_tensor)
+
+    assert output.shape == (b, features)
+
+    c = 9
+    input_tensor = torch.rand(b, c, h, w)
+
+    encoder = VisualEncoder(model_name="resnet18", in_chans=c, d_model=features)
+
+    output = encoder(input_tensor)
+
+    assert output.shape == (b, features)
 
 
 def test_embedding_validity():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -42,14 +42,19 @@ def test_att_weight_head():
     assert attn_weights.shape == (b, n, n)
 
 
-def test_encoder():
-    """Test feature extractor logic."""
+def test_encoder_timm():
+    """Test feature extractor logic using timm backend."""
     b, c, h, w = 1, 1, 100, 100  # batch size, channels, height, width
 
     features = 512
     input_tensor = torch.rand(b, c, h, w)
+    backend = "timm"
 
-    encoder = VisualEncoder(model_name="resnet18", in_chans=c, d_model=features)
+    encoder = VisualEncoder(
+        model_name="resnet18", in_chans=c, d_model=features, backend=backend
+    )
+
+    assert not isinstance(encoder.feature_extractor, torch.nn.Sequential)
 
     output = encoder(input_tensor)
 
@@ -60,7 +65,9 @@ def test_encoder():
 
     features = 128
 
-    encoder = VisualEncoder(model_name="resnet18", in_chans=c, d_model=features)
+    encoder = VisualEncoder(
+        model_name="resnet18", in_chans=c, d_model=features, backend=backend
+    )
 
     output = encoder(input_tensor)
 
@@ -69,7 +76,52 @@ def test_encoder():
     c = 9
     input_tensor = torch.rand(b, c, h, w)
 
-    encoder = VisualEncoder(model_name="resnet18", in_chans=c, d_model=features)
+    encoder = VisualEncoder(
+        model_name="resnet18", in_chans=c, d_model=features, backend=backend
+    )
+
+    output = encoder(input_tensor)
+
+    assert output.shape == (b, features)
+
+
+def test_encoder_torch():
+    """Test feature extractor logic using torchvision backend."""
+    b, c, h, w = 1, 1, 100, 100  # batch size, channels, height, width
+
+    features = 512
+    input_tensor = torch.rand(b, c, h, w)
+    backend = "torch"
+
+    encoder = VisualEncoder(
+        model_name="resnet18", in_chans=c, d_model=features, backend=backend
+    )
+
+    assert isinstance(encoder.feature_extractor, torch.nn.Sequential)
+
+    output = encoder(input_tensor)
+
+    assert output.shape == (b, features)
+
+    c = 3
+    input_tensor = torch.rand(b, c, h, w)
+
+    features = 128
+
+    encoder = VisualEncoder(
+        model_name="resnet18", in_chans=c, d_model=features, backend=backend
+    )
+
+    output = encoder(input_tensor)
+
+    assert output.shape == (b, features)
+
+    c = 9
+    input_tensor = torch.rand(b, c, h, w)
+
+    encoder = VisualEncoder(
+        model_name="resnet18", in_chans=c, d_model=features, backend=backend
+    )
 
     output = encoder(input_tensor)
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -60,7 +60,7 @@ def test_basic_gtr_runner():
                     Instance(
                         gt_track_id=k,
                         pred_track_id=-1,
-                        bbox=torch.rand(size=(1, 4)),
+                        bbox=torch.rand(size=(1, 1, 4)),
                         crop=torch.randn(size=img_shape),
                     ),
                 )
@@ -75,7 +75,6 @@ def test_basic_gtr_runner():
             )
             frame_ind += 1
         train_ds.append(frames)
-
     gtr_runner = GTRRunner()
 
     optim_scheduler = gtr_runner.configure_optimizers()


### PR DESCRIPTION
As per #32, the major failure mode we're seeing in the model while animal tracking is when nodes disappear causing a shift in visual features and a switch to occur.  We've tried randomly selecting available node, using the pose centroid as the crop, and reducing the crop size but none have worked. Instead here, we add functionality to stack crops from as many nodes along the channel dimension and use that as input into the model.
* we added timm as the backend for the visual encoder to easily enable arbitrary channel numbers
* generalized the positional encoding to work for arbitrary number of boxes
* added an MLP component to project the embedding back to the correct number of spaces
* removed mutable defaults wherever we saw it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved positional embedding handling for multiple anchors.
  - Enhanced visual encoder initialization with more flexible parameters.
  
- **Bug Fixes**
  - Added exception handling for embedding dimension mismatches.
  - Corrected input box shape handling in embeddings.

- **Enhancements**
  - Switched visual encoder's backend to `timm` for better model support.
  - Updated visual encoder to use `torch.nn.LazyLinear` for output layer initialization.

- **Tests**
  - Expanded test coverage for visual encoder and embeddings with new scenarios and parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->