### PR TITLE
Use instances as model input

### DIFF
--- a/biogtr/models/gtr_runner.py
+++ b/biogtr/models/gtr_runner.py
@@ -66,7 +66,8 @@ class GTRRunner(LightningModule):
         """Execute forward pass of the lightning module.
 
         Args:
-            instances: a list of dicts where each dict is a frame with gt data
+            ref_instances: a list of `Instance` objects containing crops and other data needed for transformer model
+            query_instances: a list of `Instance` objects used as queries in the decoder. Mostly used for inference.
 
         Returns:
             An association matrix between objects
@@ -80,8 +81,8 @@ class GTRRunner(LightningModule):
         """Execute single training step for model.
 
         Args:
-            train_batch: A single batch from the dataset which is a list of dicts
-            with length `clip_length` where each dict is a frame
+            train_batch: A single batch from the dataset which is a list of `Frame` objects
+                        with length `clip_length` containing Instances and other metadata.
             batch_idx: the batch number used by lightning
 
         Returns:
@@ -98,8 +99,8 @@ class GTRRunner(LightningModule):
         """Execute single val step for model.
 
         Args:
-            val_batch: A single batch from the dataset which is a list of dicts
-            with length `clip_length` where each dict is a frame
+            val_batch: A single batch from the dataset which is a list of `Frame` objects
+                        with length `clip_length` containing Instances and other metadata.
             batch_idx: the batch number used by lightning
 
         Returns:
@@ -116,8 +117,8 @@ class GTRRunner(LightningModule):
         """Execute single test step for model.
 
         Args:
-            val_batch: A single batch from the dataset which is a list of dicts
-            with length `clip_length` where each dict is a frame
+            test_batch: A single batch from the dataset which is a list of `Frame` objects
+                        with length `clip_length` containing Instances and other metadata.
             batch_idx: the batch number used by lightning
 
         Returns:
@@ -134,8 +135,8 @@ class GTRRunner(LightningModule):
         Computes association + assignment.
 
         Args:
-            batch: A single batch from the dataset which is a list of dicts
-            with length `clip_length` where each dict is a frame
+            batch: A single batch from the dataset which is a list of `Frame` objects
+                    with length `clip_length` containing Instances and other metadata.
             batch_idx: the batch number used by lightning
 
         Returns:
@@ -149,18 +150,16 @@ class GTRRunner(LightningModule):
         """Run evaluation used by train, test, and val steps.
 
         Args:
-            frames: A list of dicts where each dict is a frame containing gt data
+            frames: A list of `Frame` objects with length `clip_length` containing Instances and other metadata.
             mode: which metrics to compute and whether to use persistent tracking or not
 
         Returns:
             a dict containing the loss and any other metrics specified by `eval_metrics`
         """
         try:
-            frames = [frame for frame in frames if frame.has_instances()]
-            if len(frames) == 0:
-                return None
-
             instances = [instance for frame in frames for instance in frame.instances]
+            if len(instances) == 0:
+                return None
 
             eval_metrics = self.metrics[mode]
             persistent_tracking = self.persistent_tracking[mode]

--- a/biogtr/models/model_utils.py
+++ b/biogtr/models/model_utils.py
@@ -6,14 +6,15 @@ from biogtr.data_structures import Instance
 import torch
 
 
-def get_boxes(instances: List[Instance]) -> torch.tensor:
+def get_boxes(instances: List[Instance]) -> torch.Tensor:
     """Extract the bounding boxes from the input list of instances.
 
     Args:
         instances: List of Instance objects.
 
     Returns:
-        The bounding boxes normalized by the height and width of the image
+        An (n_instances, n_points, 4) float tensor containing the bounding boxes
+        normalized by the height and width of the image
     """
     boxes = []
     for i, instance in enumerate(instances):

--- a/biogtr/models/transformer.py
+++ b/biogtr/models/transformer.py
@@ -156,7 +156,6 @@ class Transformer(torch.nn.Module):
             embedding_dict: A dictionary containing the "pos" and "temp" embeddings
                             if `self.return_embeddings` is False then they are None.
         """
-
         ref_features = torch.cat(
             [instance.features for instance in ref_instances], dim=0
         ).unsqueeze(0)

--- a/biogtr/training/losses.py
+++ b/biogtr/training/losses.py
@@ -1,7 +1,7 @@
 """Module containing different loss functions to be optimized."""
 
 from biogtr.data_structures import Frame
-from biogtr.models.model_utils import get_boxes_times
+from biogtr.models.model_utils import get_boxes, get_times
 from torch import nn
 from typing import List, Tuple
 import torch
@@ -49,9 +49,11 @@ class AssoLoss(nn.Module):
         # get number of detected objects and ground truth ids
         n_t = [frame.num_detected for frame in frames]
         target_inst_id = torch.cat([frame.get_gt_track_ids() for frame in frames])
+        instances = [instance for frame in frames for instance in frame.instances]
 
         # for now set equal since detections are fixed
-        pred_box, pred_time = get_boxes_times(frames)
+        pred_box = get_boxes(instances)
+        pred_time, _ = get_times(instances)
         pred_box = torch.nanmean(pred_box, axis=1)
         target_box, target_time = pred_box, pred_time
 


### PR DESCRIPTION
Currently, at all levels we use `biogtr.Frame` as the base unit of data given to the models as an input. However, one of the core advantages of the Global Tracking Transformer is that it really associates detections. Thus, if we are able to just use detections as input into the model then at a higher level we can come up with more useful ways to group the instances when passing it into the model. Thus, here we refactor the `biogtr.models.GlobalTrackingTransformer` and `biogtr.models.Transformer` to take as input a set of `ref_instances` and a set of `query instances`. The `query_instances` are used as an input into the decoder to associate against the `ref_instances`. One level up, in `biogtr.inference.Tracker`, we basically show an example of how we can group instances by frame against window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced tracking functionality with improved instance handling and feature extraction.

- **Improvements**
  - Updated methods to operate on instances instead of frames for better efficiency.
  - Refined metrics computation and evaluation steps in model training and testing.

- **Bug Fixes**
  - Corrected bounding box extraction and time index handling to ensure accurate results.

- **Refactor**
  - Renamed and restructured functions for clarity and consistency.
  - Adjusted imports and method signatures across various modules.

- **Tests**
  - Updated test cases to align with new instance-based processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->