### PR TITLE
Patch transformer forward by replacing nan with -1 placeholder

### DIFF
--- a/biogtr/inference/tracker.py
+++ b/biogtr/inference/tracker.py
@@ -445,7 +445,13 @@ class Tracker:
         query_frame.add_traj_score("scaled", scaled_traj_score_df)
         ################################################################################
 
-        match_i, match_j = linear_sum_assignment((-traj_score))
+        try:
+            match_i, match_j = linear_sum_assignment((-traj_score))
+        except ValueError as e:
+            print(reid_features.isnan().any())
+            print(asso_output)
+            print(traj_score)
+            raise (e)
 
         track_ids = instance_ids.new_full((n_query,), -1)
         for i, j in zip(match_i, match_j):

--- a/biogtr/models/transformer.py
+++ b/biogtr/models/transformer.py
@@ -217,7 +217,7 @@ class Transformer(torch.nn.Module):
             )  # (n_query, batch_size, embed_dim)
 
             query_boxes = get_boxes(query_instances)
-
+            query_boxes = torch.nan_to_num(query_boxes, -1.0)
             query_temp_emb = self.temp_emb(query_times / window_length)
 
             query_pos_emb = self.pos_emb(query_boxes)
@@ -225,6 +225,7 @@ class Transformer(torch.nn.Module):
             query_emb = (query_pos_emb + query_temp_emb) / 2.0
             query_emb = query_emb.view(1, n_query, embed_dim)
             query_emb = query_emb.permute(1, 0, 2)  # (n_query, batch_size, embed_dim)
+
         else:
             query_instances = ref_instances
 

--- a/biogtr/models/visual_encoder.py
+++ b/biogtr/models/visual_encoder.py
@@ -144,11 +144,8 @@ class VisualEncoder(torch.nn.Module):
 
         # Reshape feature vectors
         feats = feats.reshape([img.shape[0], -1])  # (B, out_dim)
-
         # Map feature vectors to output dimension using linear layer.
         feats = self.out_layer(feats)  # (B, d_model)
-
         # Normalize output feature vectors.
         feats = F.normalize(feats)  # (B, d_model)
-
         return feats

--- a/biogtr/training/losses.py
+++ b/biogtr/training/losses.py
@@ -47,7 +47,13 @@ class AssoLoss(nn.Module):
         """
         # get number of detected objects and ground truth ids
         n_t = [frame.num_detected for frame in frames]
-        target_inst_id = torch.cat([frame.get_gt_track_ids() for frame in frames])
+        try:
+            target_inst_id = torch.cat(
+                [frame.get_gt_track_ids().to(asso_preds[-1].device) for frame in frames]
+            )
+        except RuntimeError as e:
+            print([frame.get_gt_track_ids().device for frame in frames])
+            raise (e)
         instances = [instance for frame in frames for instance in frame.instances]
 
         # for now set equal since detections are fixed


### PR DESCRIPTION
I realized there was a small bug in the forward pass of the transformer where I forgot to replace the query instance's boxes w -1 when theyre missing. Fixed it here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in various components to ensure smoother execution and better debugging information.
  - Fixed potential issues with NaN values in `query_boxes` by replacing them with `-1.0`.

- **Refactor**
  - Streamlined the processing steps in the `VisualEncoder` for better readability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->